### PR TITLE
🔀 :: (#51) 알림 히스토리 가져오기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,11 @@ configurations {
     }
 }
 
+compileJava {
+    options.compilerArgs << '-Amapstruct.defaultComponentModel=spring'
+}
+
+
 repositories {
     mavenCentral()
 }
@@ -37,7 +42,7 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:3.1.4'
     compileOnly 'org.projectlombok:lombok'
-    annotationProcessor 'org.projectlombok:lombok'
+
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
@@ -45,6 +50,16 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
     implementation 'io.github.openfeign:feign-httpclient:12.0'
+
+    implementation 'org.mapstruct:mapstruct:1.4.2.Final'
+    implementation 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
+    //순서 중요
+    annotationProcessor "org.mapstruct:mapstruct-processor:1.4.1.Final"
+    annotationProcessor "org.projectlombok:lombok-mapstruct-binding:0.2.0"
+    annotationProcessor 'org.projectlombok:lombok'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/AlarmType.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/AlarmType.java
@@ -1,0 +1,31 @@
+package io.github.depromeet.knockknockbackend.domain.notification.domain;
+
+import java.util.Arrays;
+
+public enum AlarmType {
+
+    ONETOONE(0),
+    ONETOGROUP(1);
+
+    private final Integer dbData;
+
+    AlarmType(Integer dbData) {
+        this.dbData = dbData;
+    }
+
+    public static AlarmType ofDbData(Integer dbData) {
+        return Arrays.stream(AlarmType.values())
+            .filter(alarmType -> alarmType.isEquivalentTo(dbData))
+            .findAny()
+            .orElseThrow();
+    }
+
+    private boolean isEquivalentTo(Integer dbData) {
+        return this.dbData.equals(dbData);
+    }
+
+    public int getDbData() {
+        return dbData;
+    }
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/AlarmTypeConverter.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/AlarmTypeConverter.java
@@ -1,0 +1,17 @@
+package io.github.depromeet.knockknockbackend.domain.notification.domain;
+
+import javax.persistence.AttributeConverter;
+
+public class AlarmTypeConverter implements AttributeConverter<AlarmType, Integer> {
+
+
+    @Override
+    public Integer convertToDatabaseColumn(AlarmType attribute) {
+        return attribute.getDbData();
+    }
+
+    @Override
+    public AlarmType convertToEntityAttribute(Integer dbData) {
+        return AlarmType.ofDbData(dbData);
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/Notification.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/Notification.java
@@ -12,17 +12,19 @@ import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tbl_notification")
 @Entity
 public class Notification {
-
-    public static final Integer DEFAULT_PAGE = 0;
-    public static final Integer DEFAULT_PAGE_SIZE = 5;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/Notification.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/Notification.java
@@ -1,0 +1,51 @@
+package io.github.depromeet.knockknockbackend.domain.notification.domain;
+
+import io.github.depromeet.knockknockbackend.domain.user.domain.User;
+import java.time.LocalDateTime;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tbl_notification")
+@Entity
+public class Notification {
+
+    public static final Integer DEFAULT_PAGE = 0;
+    public static final Integer DEFAULT_PAGE_SIZE = 5;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private LocalDateTime sendAt;
+
+    private String content;
+
+    private String imageUrl;
+
+    @Convert(converter = AlarmTypeConverter.class)
+    private AlarmType alarmType;
+
+    //+그룹아이디
+
+    @JoinColumn(name = "send_user_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    private User sendUser;
+
+    @JoinColumn(name = "receive_user_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    private User receiveUser;
+
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/repository/NotificationRepository.java
@@ -1,0 +1,13 @@
+package io.github.depromeet.knockknockbackend.domain.notification.domain.repository;
+
+import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
+import io.github.depromeet.knockknockbackend.domain.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.CrudRepository;
+
+public interface NotificationRepository extends CrudRepository<Notification, Long> {
+
+    Page<Notification> findAllByReceiveUser(User receiveUser, Pageable pageable);
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/repository/NotificationRepository.java
@@ -1,13 +1,12 @@
 package io.github.depromeet.knockknockbackend.domain.notification.domain.repository;
 
 import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
-import io.github.depromeet.knockknockbackend.domain.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.CrudRepository;
 
 public interface NotificationRepository extends CrudRepository<Notification, Long> {
 
-    Page<Notification> findAllByReceiveUser(User receiveUser, Pageable pageable);
+    Page<Notification> findAllByReceiveUserId(Long receiveUserId, Pageable pageable);
 
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
@@ -3,6 +3,8 @@ package io.github.depromeet.knockknockbackend.domain.notification.presentation;
 import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
 import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponse;
 import io.github.depromeet.knockknockbackend.domain.notification.service.NotificationService;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +12,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@SecurityRequirement(name = "access-token")
+@Tag(name = "알람 관련 컨트롤러", description = "")
 @RequiredArgsConstructor
 @RequestMapping("/notifications")
 @RestController

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
@@ -1,0 +1,27 @@
+package io.github.depromeet.knockknockbackend.domain.notification.presentation;
+
+import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
+import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponse;
+import io.github.depromeet.knockknockbackend.domain.notification.service.NotificationService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/notifications")
+@RestController
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping("/history")
+    public QueryAlarmHistoryResponse queryAlarmHistoryByUserId(
+        @RequestParam("page") Optional<Integer> page,
+        @RequestParam("size") Optional<Integer> size) {
+        return notificationService.queryAlarmHistoryByUserId(page.orElse(Notification.DEFAULT_PAGE),
+            size.orElse(Notification.DEFAULT_PAGE_SIZE));
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
@@ -1,15 +1,15 @@
 package io.github.depromeet.knockknockbackend.domain.notification.presentation;
 
-import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
 import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponse;
 import io.github.depromeet.knockknockbackend.domain.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @SecurityRequirement(name = "access-token")
@@ -23,9 +23,7 @@ public class NotificationController {
 
     @GetMapping("/history")
     public QueryAlarmHistoryResponse queryAlarmHistoryByUserId(
-        @RequestParam("page") Optional<Integer> page,
-        @RequestParam("size") Optional<Integer> size) {
-        return notificationService.queryAlarmHistoryByUserId(page.orElse(Notification.DEFAULT_PAGE),
-            size.orElse(Notification.DEFAULT_PAGE_SIZE));
+        @PageableDefault(size = 5, sort = "sendAt", direction = Direction.DESC) Pageable pageable) {
+        return notificationService.queryAlarmHistoryByUserId(pageable);
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/response/QueryAlarmHistoryResponse.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/response/QueryAlarmHistoryResponse.java
@@ -1,0 +1,14 @@
+package io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+@AllArgsConstructor
+public class QueryAlarmHistoryResponse {
+
+    private final List<QueryAlarmHistoryResponseElement> alarmHistory;
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/response/QueryAlarmHistoryResponseElement.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/response/QueryAlarmHistoryResponseElement.java
@@ -1,0 +1,32 @@
+package io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response;
+
+import io.github.depromeet.knockknockbackend.domain.notification.domain.AlarmType;
+import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class QueryAlarmHistoryResponseElement {
+
+    private String sendUserNickname;
+    private LocalDateTime sendAt;
+    private String content;
+    private String imageUrl;
+    private AlarmType alarmType;
+
+    public static QueryAlarmHistoryResponseElement from(Notification notification) {
+        return QueryAlarmHistoryResponseElement.builder()
+            .sendUserNickname(notification.getSendUser().getNickname())
+            .sendAt(notification.getSendAt())
+            .content(notification.getContent())
+            .imageUrl(notification.getImageUrl())
+            .alarmType(notification.getAlarmType())
+            .build();
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/response/QueryAlarmHistoryResponseElement.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/response/QueryAlarmHistoryResponseElement.java
@@ -1,7 +1,6 @@
 package io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response;
 
 import io.github.depromeet.knockknockbackend.domain.notification.domain.AlarmType;
-import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -10,7 +9,7 @@ import lombok.Getter;
 
 
 @Getter
-@Builder(access = AccessLevel.PRIVATE)
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class QueryAlarmHistoryResponseElement {
 
@@ -20,13 +19,4 @@ public class QueryAlarmHistoryResponseElement {
     private String imageUrl;
     private AlarmType alarmType;
 
-    public static QueryAlarmHistoryResponseElement from(Notification notification) {
-        return QueryAlarmHistoryResponseElement.builder()
-            .sendUserNickname(notification.getSendUser().getNickname())
-            .sendAt(notification.getSendAt())
-            .content(notification.getContent())
-            .imageUrl(notification.getImageUrl())
-            .alarmType(notification.getAlarmType())
-            .build();
-    }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationMapper.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationMapper.java
@@ -1,0 +1,15 @@
+package io.github.depromeet.knockknockbackend.domain.notification.service;
+
+import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
+import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponseElement;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+
+@Mapper
+public interface NotificationMapper {
+
+    @Mapping(source = "sendUser.nickname", target = "sendUserNickname")
+    QueryAlarmHistoryResponseElement toDtoForQueryAlarmHistory(Notification notification);
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -18,13 +18,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final NotificationMapper notificationMapper;
 
     @Transactional
     public QueryAlarmHistoryResponse queryAlarmHistoryByUserId(Pageable pageable) {
         Page<Notification> alarmHistory = notificationRepository.findAllByReceiveUserId(SecurityUtils.getCurrentUserId(), pageable);
 
         List<QueryAlarmHistoryResponseElement> result = alarmHistory.stream()
-            .map(notification -> QueryAlarmHistoryResponseElement.from(notification))
+            .map(notification -> notificationMapper.toDtoForQueryAlarmHistory(notification))
             .collect(Collectors.toList());
 
         return new QueryAlarmHistoryResponse(result);

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -4,13 +4,12 @@ import io.github.depromeet.knockknockbackend.domain.notification.domain.Notifica
 import io.github.depromeet.knockknockbackend.domain.notification.domain.repository.NotificationRepository;
 import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponse;
 import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponseElement;
-import io.github.depromeet.knockknockbackend.domain.user.domain.User;
 import io.github.depromeet.knockknockbackend.global.utils.security.SecurityUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,9 +20,8 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
 
     @Transactional
-    public QueryAlarmHistoryResponse queryAlarmHistoryByUserId(Integer page, Integer size) {
-        PageRequest pageRequest = PageRequest.of(page, size);
-        Page<Notification> alarmHistory = notificationRepository.findAllByReceiveUser(User.of(SecurityUtils.getCurrentUserId()), pageRequest);
+    public QueryAlarmHistoryResponse queryAlarmHistoryByUserId(Pageable pageable) {
+        Page<Notification> alarmHistory = notificationRepository.findAllByReceiveUserId(SecurityUtils.getCurrentUserId(), pageable);
 
         List<QueryAlarmHistoryResponseElement> result = alarmHistory.stream()
             .map(notification -> QueryAlarmHistoryResponseElement.from(notification))

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -1,0 +1,34 @@
+package io.github.depromeet.knockknockbackend.domain.notification.service;
+
+import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
+import io.github.depromeet.knockknockbackend.domain.notification.domain.repository.NotificationRepository;
+import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponse;
+import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponseElement;
+import io.github.depromeet.knockknockbackend.domain.user.domain.User;
+import io.github.depromeet.knockknockbackend.global.utils.security.SecurityUtils;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public QueryAlarmHistoryResponse queryAlarmHistoryByUserId(Integer page, Integer size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<Notification> alarmHistory = notificationRepository.findAllByReceiveUser(User.of(SecurityUtils.getCurrentUserId()), pageRequest);
+
+        List<QueryAlarmHistoryResponseElement> result = alarmHistory.stream()
+            .map(notification -> QueryAlarmHistoryResponseElement.from(notification))
+            .collect(Collectors.toList());
+
+        return new QueryAlarmHistoryResponse(result);
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/User.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/User.java
@@ -42,6 +42,9 @@ public class User {
         this.email = email;
     }
 
+    public User(Long userId) {
+		this.id = userId;
+	}
     public UserInfoVO getUserInfo() {
         return new UserInfoVO(id, nickname, profilePath);
     }
@@ -50,4 +53,7 @@ public class User {
         this.nickname = nickname;
     }
 
+    public static User of(Long userId) {
+        return new User(userId);
+    }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/User.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/User.java
@@ -41,10 +41,6 @@ public class User {
         this.oauthId = oauthId;
         this.email = email;
     }
-
-    public User(Long userId) {
-		this.id = userId;
-	}
     public UserInfoVO getUserInfo() {
         return new UserInfoVO(id, nickname, profilePath);
     }
@@ -53,7 +49,4 @@ public class User {
         this.nickname = nickname;
     }
 
-    public static User of(Long userId) {
-        return new User(userId);
-    }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/infrastructor/fcm/FcmConfig.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/infrastructor/fcm/FcmConfig.java
@@ -20,10 +20,11 @@ public class FcmConfig {
     @PostConstruct
     private void initialize() {
         try {
-            if(FirebaseApp.getApps().isEmpty()) {
+            if (FirebaseApp.getApps().isEmpty()) {
                 FirebaseOptions options = FirebaseOptions.builder()
-                        .setCredentials(GoogleCredentials.fromStream(new ByteArrayInputStream(fcmValue.getBytes(StandardCharsets.UTF_8))))
-                        .build();
+                    .setCredentials(GoogleCredentials.getApplicationDefault())
+//                        .setCredentials(GoogleCredentials.fromStream(new ByteArrayInputStream(fcmValue.getBytes(StandardCharsets.UTF_8))))
+                    .build();
                 FirebaseApp.initializeApp(options);
             }
         } catch (IOException e) {


### PR DESCRIPTION
코드량이 많지 않지만 앞으로의 코드에 반영하기 위해 PR보냅니다.
리뷰 부탁드려요 😀

- URI : GET  /notifications/history 
- 적용 위치 : 마이페이지/보관함 

### 🔹적용 및 특이 사항
1.  페이지 적용
	-  기획서 상에는 특별히 없었지만 페이지를 적용해보았습니다.
	-  page, size 를 파라미터로 보내야하는데, 없을 경우 기본값으로 적용되도록 하였습니다.
2.  알람타입 DB 저장값
   -  알람타입을 일대일 경우 0, 일대그룹일 경우 1 로 저장하기로 되어 있었는데요.
   -  자바 코드 내부와 클라이언트와의 소통은 코드명 대신 일대일(ONETOONE), 일대그룹(ONETOGROUP)으로 표현하도록 하였습니다. 


### 🔹Response Body 예시
```json
{
  "alarm_history": [
    {
      "send_user_nickname": "je",
      "send_at": "2022-11-17T23:08:55",
      "content": "알람보냈다",
      "image_url": "http://image.com",
      "alarm_type": "ONETOONE"
    }
  ]
}
```