### PR TITLE
🔀 :: (#62) FCM Token 가져오기 

### DIFF
--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/DeviceToken.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/DeviceToken.java
@@ -1,0 +1,46 @@
+package io.github.depromeet.knockknockbackend.domain.notification.domain;
+
+import io.github.depromeet.knockknockbackend.global.database.BaseTimeEntity;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tbl_device_token")
+@Entity
+public class DeviceToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private String deviceId;
+
+    private String token;
+
+
+    public static DeviceToken of(Long userId, String deviceId, String deviceToken) {
+        return DeviceToken.builder()
+            .userId(userId)
+            .deviceId(deviceId)
+            .token(deviceToken)
+            .build();
+    }
+
+    public DeviceToken changeToken(String token) {
+        this.token = token;
+        return this;
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/DeviceToken.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/DeviceToken.java
@@ -1,6 +1,7 @@
 package io.github.depromeet.knockknockbackend.domain.notification.domain;
 
 import io.github.depromeet.knockknockbackend.global.database.BaseTimeEntity;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -28,6 +29,7 @@ public class DeviceToken extends BaseTimeEntity {
 
     private String deviceId;
 
+    @Column(unique = true)
     private String token;
 
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/repository/DeviceTokenRepository.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/repository/DeviceTokenRepository.java
@@ -1,0 +1,10 @@
+package io.github.depromeet.knockknockbackend.domain.notification.domain.repository;
+
+import io.github.depromeet.knockknockbackend.domain.notification.domain.DeviceToken;
+import java.util.Optional;
+import org.springframework.data.repository.CrudRepository;
+
+public interface DeviceTokenRepository extends CrudRepository<DeviceToken, Long> {
+    Optional<DeviceToken> findByDeviceId(String deviceId);
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,7 +34,8 @@ public class NotificationController {
 
     @PostMapping("/token")
     public ResponseEntity<Void> registerFcmToken(@RequestBody RegisterFcmTokenRequest request) {
-        return new ResponseEntity<>(notificationService.registerFcmToken(request));
+        notificationService.registerFcmToken(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
@@ -1,5 +1,6 @@
 package io.github.depromeet.knockknockbackend.domain.notification.presentation;
 
+import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.request.RegisterFcmTokenRequest;
 import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponse;
 import io.github.depromeet.knockknockbackend.domain.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -8,7 +9,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,4 +30,10 @@ public class NotificationController {
         @PageableDefault(size = 5, sort = "sendAt", direction = Direction.DESC) Pageable pageable) {
         return notificationService.queryAlarmHistoryByUserId(pageable);
     }
+
+    @PostMapping("/token")
+    public ResponseEntity<Void> registerFcmToken(@RequestBody RegisterFcmTokenRequest request) {
+        return new ResponseEntity<>(notificationService.registerFcmToken(request));
+    }
+
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/request/RegisterFcmTokenRequest.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/request/RegisterFcmTokenRequest.java
@@ -1,0 +1,11 @@
+package io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class RegisterFcmTokenRequest {
+
+    private String deviceId;
+    private String deviceToken;
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/request/RegisterFcmTokenRequest.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/request/RegisterFcmTokenRequest.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 public class RegisterFcmTokenRequest {
 
     private String deviceId;
-    private String deviceToken;
+    private String token;
 
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -1,15 +1,20 @@
 package io.github.depromeet.knockknockbackend.domain.notification.service;
 
+import io.github.depromeet.knockknockbackend.domain.notification.domain.DeviceToken;
 import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
+import io.github.depromeet.knockknockbackend.domain.notification.domain.repository.DeviceTokenRepository;
 import io.github.depromeet.knockknockbackend.domain.notification.domain.repository.NotificationRepository;
+import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.request.RegisterFcmTokenRequest;
 import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponse;
 import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponseElement;
 import io.github.depromeet.knockknockbackend.global.utils.security.SecurityUtils;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,16 +23,40 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+
     private final NotificationMapper notificationMapper;
 
     @Transactional
     public QueryAlarmHistoryResponse queryAlarmHistoryByUserId(Pageable pageable) {
-        Page<Notification> alarmHistory = notificationRepository.findAllByReceiveUserId(SecurityUtils.getCurrentUserId(), pageable);
+        Page<Notification> alarmHistory = notificationRepository.findAllByReceiveUserId(
+            SecurityUtils.getCurrentUserId(), pageable);
 
         List<QueryAlarmHistoryResponseElement> result = alarmHistory.stream()
-            .map(notification -> notificationMapper.toDtoForQueryAlarmHistory(notification))
+            .map(notificationMapper::toDtoForQueryAlarmHistory)
             .collect(Collectors.toList());
 
         return new QueryAlarmHistoryResponse(result);
+    }
+
+    @Transactional
+    public HttpStatus registerFcmToken(RegisterFcmTokenRequest request) {
+        Long currentUserId = SecurityUtils.getCurrentUserId();
+        Optional<DeviceToken> deviceTokenOptional = deviceTokenRepository.findByDeviceId(
+            request.getDeviceId());
+
+        deviceTokenOptional.filter(deviceToken -> !deviceToken.getUserId().equals(currentUserId))
+            .ifPresent(deviceToken -> {
+                deviceTokenRepository.deleteById(deviceToken.getId());
+                deviceTokenRepository.save(
+                    DeviceToken.of(currentUserId, request.getDeviceId(), request.getDeviceToken()));
+            });
+
+        deviceTokenOptional.filter(deviceToken -> deviceToken.getUserId().equals(currentUserId)
+                && !deviceToken.getToken().equals(request.getDeviceToken()))
+            .ifPresent(deviceToken -> deviceTokenRepository.save(
+                deviceToken.changeToken(request.getDeviceToken())));
+
+        return HttpStatus.CREATED;
     }
 }


### PR DESCRIPTION
클라이언트 앱에서 FCM Token 가져와 저장하는 로직입니다. 

### 참고 사항
- deviceId는 기기 고유 값으로 유니크하게 설정(하나의 기기에 하나의 토큰만 관리)
- 그러나 제대로 로그아웃처리가 안됐을 경우 deviceId에 다른 계정의 토큰이 저장되어 있을 경우 삭제
- deviceId 존재 여부를 매번 full table scan : index 생성 필요
- unique 권한은 주지 않았는데 그 이유는, JPA에서는 insert가 가장 먼저 수행