### PR TITLE
🔀 :: (#75) 그룹 초대 요청 ( 기획에서 빠짐 )

### DIFF
--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/GroupUsers.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/GroupUsers.java
@@ -50,17 +50,17 @@ public class GroupUsers {
             .collect(Collectors.toList());
     }
 
-    public void validReqUserIsGroupHost(User reqUser) {
+    public void validReqUserIsGroupHost(Long reqUserId) {
         groupUserList.stream()
-            .filter(groupUser -> groupUser.getUser().equals(reqUser) && groupUser.getIsHost())
+            .filter(groupUser -> groupUser.getUserId().equals(reqUserId) && groupUser.getIsHost())
             .findFirst()
             .orElseThrow(() -> NotHostException.EXCEPTION);
     }
 
-    public Boolean checkReqUserGroupHost(User reqUser) {
+    public Boolean checkReqUserGroupHost(Long reqUserId) {
         return groupUserList.stream()
             .anyMatch(groupUser ->
-                groupUser.getIsHost() && groupUser.getUser().getId().equals(reqUser.getId()));
+                groupUser.getIsHost() && groupUser.getUserId().equals(reqUserId));
 
     }
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/GroupUsers.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/GroupUsers.java
@@ -104,4 +104,12 @@ public class GroupUsers {
         groupUserList.removeIf(groupUser -> groupUser.getUserId().equals(userId));
     }
 
+    public void validInviteUsersAlreadyEnterGroup(List<Long> requestMemberIds){
+        boolean checkInviteUsersAlreadyEnterGroup = getUserIds().stream()
+            .anyMatch(id -> requestMemberIds.contains(id));
+        if(checkInviteUsersAlreadyEnterGroup){
+            throw AlreadyGroupEnterException.EXCEPTION;
+        }
+    }
+
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/Invite.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/Invite.java
@@ -29,9 +29,12 @@ public class Invite extends BaseTimeEntity {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "receive_id")
+    @JoinColumn(name = "receiver_id")
     private User receiver;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private User sender;
     @ManyToOne
     @JoinColumn(name = "group_id")
     private Group group;
@@ -41,17 +44,19 @@ public class Invite extends BaseTimeEntity {
 
 
     @Builder
-    public Invite(User receiver, Group group,
+    public Invite(User receiver, User sender,Group group,
         InviteState inviteState) {
         this.receiver = receiver;
+        this.sender = sender;
         this.group = group;
         this.inviteState = inviteState;
     }
 
-    public static Invite createInvite(User receiver, Group group){
+    public static Invite createInvite(User receiver,User sender, Group group){
         return Invite.builder()
             .inviteState(InviteState.PENDING)
             .receiver(receiver)
+            .sender(sender)
             .group(group)
             .build();
     }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/Invite.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/Invite.java
@@ -1,0 +1,65 @@
+package io.github.depromeet.knockknockbackend.domain.group.domain;
+
+
+import io.github.depromeet.knockknockbackend.domain.user.domain.User;
+import io.github.depromeet.knockknockbackend.global.database.BaseTimeEntity;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Table(name = "tbl_group_admission")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Invite extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receive_id")
+    private User receiver;
+
+    @ManyToOne
+    @JoinColumn(name = "group_id")
+    private Group group;
+
+    @Enumerated(value = EnumType.STRING)
+    private InviteState inviteState;
+
+
+    @Builder
+    public Invite(User receiver, Group group,
+        InviteState inviteState) {
+        this.receiver = receiver;
+        this.group = group;
+        this.inviteState = inviteState;
+    }
+
+    public static Invite createInvite(User receiver, Group group){
+        return Invite.builder()
+            .inviteState(InviteState.PENDING)
+            .receiver(receiver)
+            .group(group)
+            .build();
+    }
+
+    public void refuseInvite(){
+        inviteState = InviteState.REFUSE;
+    }
+    public void acceptInvite(){
+        inviteState = InviteState.ACCEPT;
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/Invite.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/Invite.java
@@ -20,7 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Table(name = "tbl_group_admission")
+@Table(name = "tbl_group_invite")
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Invite extends BaseTimeEntity {

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/InviteState.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/InviteState.java
@@ -1,0 +1,14 @@
+package io.github.depromeet.knockknockbackend.domain.group.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum InviteState {
+    PENDING("PENDING"),
+    ACCEPT("ACCEPT"),
+    REFUSE("REFUSE");
+
+    private String value;
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/repository/InviteRepository.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/repository/InviteRepository.java
@@ -1,0 +1,8 @@
+package io.github.depromeet.knockknockbackend.domain.group.domain.repository;
+
+import io.github.depromeet.knockknockbackend.domain.group.domain.Invite;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InviteRepository extends JpaRepository<Invite, Long> {
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/exception/InviteNotFoundException.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/exception/InviteNotFoundException.java
@@ -1,0 +1,12 @@
+package io.github.depromeet.knockknockbackend.domain.group.exception;
+
+import io.github.depromeet.knockknockbackend.global.error.exception.ErrorCode;
+import io.github.depromeet.knockknockbackend.global.error.exception.KnockException;
+
+public class InviteNotFoundException extends KnockException {
+    public static final KnockException EXCEPTION = new InviteNotFoundException();
+
+    private InviteNotFoundException() {
+        super(ErrorCode.INVITE_NOT_FOUND);
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
@@ -2,6 +2,7 @@ package io.github.depromeet.knockknockbackend.domain.group.facade;
 
 
 import io.github.depromeet.knockknockbackend.domain.group.domain.Group;
+import io.github.depromeet.knockknockbackend.domain.group.domain.GroupUsers;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.request.AddFriendToGroupRequest;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.AdmissionInfoDto;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.AdmissionInfoListResponse;
@@ -52,9 +53,12 @@ public class AdmissionFacade {
     }
 
     public GroupResponse addMembersToGroup(Long groupId, List<Long> requestMemberIds) {
+        // 이미 방안에 들어갔는지 검증
         Group group = groupService.queryGroup(groupId);
+        GroupUsers groupUsers = group.getGroupUsers();
+        groupUsers.validInviteUsersAlreadyEnterGroup(requestMemberIds);
+        // 내 친구 목록 불러오기
         Long userId = SecurityUtils.getCurrentUserId();
-
         List<Long> myFriendList = relationUtils.findMyFriendUserIdList(userId);
 
         //요청한 목록 중에서 내 친구 인 사람
@@ -66,7 +70,9 @@ public class AdmissionFacade {
             !myFriendList.contains(id)
         ).collect(Collectors.toList());
 
+        // 초대 요청 보내기
         admissionService.requestAdmissions(group ,requestAdmissionIds);
+        // 내 친구 목록에 있는 사람들은 그냥 방안에 넣기
         return groupService.addMembersToGroup(groupId ,addMemberList);
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
@@ -2,20 +2,10 @@ package io.github.depromeet.knockknockbackend.domain.group.facade;
 
 
 import io.github.depromeet.knockknockbackend.domain.group.domain.Group;
-import io.github.depromeet.knockknockbackend.domain.group.domain.GroupType;
-import io.github.depromeet.knockknockbackend.domain.group.domain.GroupUsers;
-import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.request.AddFriendToGroupRequest;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.AdmissionInfoDto;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.AdmissionInfoListResponse;
-import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.GroupResponse;
 import io.github.depromeet.knockknockbackend.domain.group.service.AdmissionService;
 import io.github.depromeet.knockknockbackend.domain.group.service.GroupService;
-import io.github.depromeet.knockknockbackend.domain.user.domain.User;
-import io.github.depromeet.knockknockbackend.global.utils.relation.RelationUtils;
-import io.github.depromeet.knockknockbackend.global.utils.security.SecurityUtils;
-import io.github.depromeet.knockknockbackend.global.utils.user.UserUtils;
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
@@ -51,15 +51,15 @@ public class AdmissionFacade {
         Group group = groupService.queryGroup(groupId);
         return admissionService.refuseAdmission(group,admissionId);
     }
-
     public GroupResponse addMembersToGroup(Long groupId, List<Long> requestMemberIds) {
+        Long reqUserId = SecurityUtils.getCurrentUserId();
+
         // 이미 방안에 들어갔는지 검증
         Group group = groupService.queryGroup(groupId);
         GroupUsers groupUsers = group.getGroupUsers();
         groupUsers.validInviteUsersAlreadyEnterGroup(requestMemberIds);
         // 내 친구 목록 불러오기
-        Long userId = SecurityUtils.getCurrentUserId();
-        List<Long> myFriendList = relationUtils.findMyFriendUserIdList(userId);
+        List<Long> myFriendList = relationUtils.findMyFriendUserIdList(reqUserId);
 
         //요청한 목록 중에서 내 친구 인 사람
         List<Long> addMemberList = requestMemberIds.stream().filter(id ->
@@ -71,8 +71,8 @@ public class AdmissionFacade {
         ).collect(Collectors.toList());
 
         // 초대 요청 보내기
-        admissionService.requestAdmissions(group ,requestAdmissionIds , userId);
+        admissionService.requestAdmissions(group ,requestAdmissionIds , reqUserId);
         // 내 친구 목록에 있는 사람들은 그냥 방안에 넣기
-        return groupService.addMembersToGroup(group ,addMemberList , userId);
+        return groupService.addMembersToGroup(group ,addMemberList , reqUserId);
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
@@ -71,8 +71,8 @@ public class AdmissionFacade {
         ).collect(Collectors.toList());
 
         // 초대 요청 보내기
-        admissionService.requestAdmissions(group ,requestAdmissionIds);
+        admissionService.requestAdmissions(group ,requestAdmissionIds , userId);
         // 내 친구 목록에 있는 사람들은 그냥 방안에 넣기
-        return groupService.addMembersToGroup(groupId ,addMemberList);
+        return groupService.addMembersToGroup(group ,addMemberList , userId);
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
@@ -2,6 +2,7 @@ package io.github.depromeet.knockknockbackend.domain.group.facade;
 
 
 import io.github.depromeet.knockknockbackend.domain.group.domain.Group;
+import io.github.depromeet.knockknockbackend.domain.group.domain.GroupType;
 import io.github.depromeet.knockknockbackend.domain.group.domain.GroupUsers;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.request.AddFriendToGroupRequest;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.AdmissionInfoDto;
@@ -59,19 +60,23 @@ public class AdmissionFacade {
         GroupUsers groupUsers = group.getGroupUsers();
         groupUsers.validInviteUsersAlreadyEnterGroup(requestMemberIds);
         // 내 친구 목록 불러오기
+
         List<Long> myFriendList = relationUtils.findMyFriendUserIdList(reqUserId);
+
+        //요청한 목록 중에서 내 친구 아닌 사람
+        // 초대 요청 보내기
+        if(group.getGroupType().equals(GroupType.OPEN)){
+            List<Long> requestAdmissionIds = requestMemberIds.stream().filter(id ->
+                !myFriendList.contains(id)
+            ).collect(Collectors.toList());
+            admissionService.requestAdmissions(group ,requestAdmissionIds , reqUserId);
+        }
 
         //요청한 목록 중에서 내 친구 인 사람
         List<Long> addMemberList = requestMemberIds.stream().filter(id ->
             myFriendList.contains(id)
         ).collect(Collectors.toList());
-        //요청한 목록 중에서 내 친구 아닌 사람
-        List<Long> requestAdmissionIds = requestMemberIds.stream().filter(id ->
-            !myFriendList.contains(id)
-        ).collect(Collectors.toList());
 
-        // 초대 요청 보내기
-        admissionService.requestAdmissions(group ,requestAdmissionIds , reqUserId);
         // 내 친구 목록에 있는 사람들은 그냥 방안에 넣기
         return groupService.addMembersToGroup(group ,addMemberList , reqUserId);
     }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/facade/AdmissionFacade.java
@@ -28,8 +28,6 @@ public class AdmissionFacade {
     private final AdmissionService admissionService;
     private final GroupService groupService;
 
-    private final RelationUtils relationUtils;
-
     public AdmissionInfoDto requestAdmission(Long groupId) {
         Group group = groupService.queryGroup(groupId);
         return admissionService.requestAdmission(group);
@@ -51,33 +49,5 @@ public class AdmissionFacade {
     public AdmissionInfoDto refuseAdmission(Long groupId, Long admissionId) {
         Group group = groupService.queryGroup(groupId);
         return admissionService.refuseAdmission(group,admissionId);
-    }
-    public GroupResponse addMembersToGroup(Long groupId, List<Long> requestMemberIds) {
-        Long reqUserId = SecurityUtils.getCurrentUserId();
-
-        // 이미 방안에 들어갔는지 검증
-        Group group = groupService.queryGroup(groupId);
-        GroupUsers groupUsers = group.getGroupUsers();
-        groupUsers.validInviteUsersAlreadyEnterGroup(requestMemberIds);
-        // 내 친구 목록 불러오기
-
-        List<Long> myFriendList = relationUtils.findMyFriendUserIdList(reqUserId);
-
-        //요청한 목록 중에서 내 친구 아닌 사람
-        // 초대 요청 보내기
-        if(group.getGroupType().equals(GroupType.OPEN)){
-            List<Long> requestAdmissionIds = requestMemberIds.stream().filter(id ->
-                !myFriendList.contains(id)
-            ).collect(Collectors.toList());
-            admissionService.requestAdmissions(group ,requestAdmissionIds , reqUserId);
-        }
-
-        //요청한 목록 중에서 내 친구 인 사람
-        List<Long> addMemberList = requestMemberIds.stream().filter(id ->
-            myFriendList.contains(id)
-        ).collect(Collectors.toList());
-
-        // 내 친구 목록에 있는 사람들은 그냥 방안에 넣기
-        return groupService.addMembersToGroup(group ,addMemberList , reqUserId);
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/presentation/GroupController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/presentation/GroupController.java
@@ -149,7 +149,7 @@ public class GroupController {
         return groupService.searchOpenGroups(searchString);
     }
 
-    @Operation(summary = "방장 권한 멤버 추가")
+    @Operation(summary = "멤버 초대 하기 , 요청한 목록이 내친구일때는 바로 초대, 아닐경우 초대")
     @PostMapping("/{id}/members")
     public GroupResponse addMembers(
         @PathVariable(value = "id") Long groupId,

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/presentation/GroupController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/presentation/GroupController.java
@@ -154,7 +154,7 @@ public class GroupController {
     public GroupResponse addMembers(
         @PathVariable(value = "id") Long groupId,
         @Valid @RequestBody AddFriendToGroupRequest addFriendToGroupRequest){
-        return groupService.addMembersToGroup(groupId , addFriendToGroupRequest);
+        return admissionFacade.addMembersToGroup(groupId , addFriendToGroupRequest.getMemberIds());
     }
 
     @Operation(summary = "멤버 제거 ( 방장일 경우 본인빼고 모든인원 , 멤버일경우 나만)")

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/presentation/GroupController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/presentation/GroupController.java
@@ -154,7 +154,7 @@ public class GroupController {
     public GroupResponse addMembers(
         @PathVariable(value = "id") Long groupId,
         @Valid @RequestBody AddFriendToGroupRequest addFriendToGroupRequest){
-        return admissionFacade.addMembersToGroup(groupId , addFriendToGroupRequest.getMemberIds());
+        return groupService.addMembersToGroup(groupId , addFriendToGroupRequest.getMemberIds());
     }
 
     @Operation(summary = "멤버 제거 ( 방장일 경우 본인빼고 모든인원 , 멤버일경우 나만)")

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/AdmissionService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/AdmissionService.java
@@ -106,15 +106,4 @@ public class AdmissionService {
         return getAdmissionInfoDto(admission);
     }
 
-
-    public List<Admission> requestAdmissions(Group group, List<Long> requestAdmissionIds, Long reqUserId) {
-        List<User> users = userUtils.findByIdIn(requestAdmissionIds);
-        //TODO : 요청시 알림 넣어주기?
-
-        List<Admission> admissionList = users.stream()
-            .map(user -> Admission.createAdmission(user, group))
-            .collect(Collectors.toList());
-        admissionRepository.saveAll(admissionList);
-        return admissionList;
-    }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/AdmissionService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/AdmissionService.java
@@ -105,5 +105,13 @@ public class AdmissionService {
 
 
     public void requestAdmissions(Group group, List<Long> requestAdmissionIds) {
+        User reqUser = userUtils.getUserFromSecurityContext();
+        GroupUsers groupUsers = group.getGroupUsers();
+        groupUsers.validUserIsAlreadyEnterGroup(reqUser);
+
+        //TODO : 요청시 알림 넣어주기?
+        Admission admission = Admission.createAdmission(reqUser, group);
+        admissionRepository.save(admission);
+
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/AdmissionService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/AdmissionService.java
@@ -104,4 +104,6 @@ public class AdmissionService {
     }
 
 
+    public void requestAdmissions(Group group, List<Long> requestAdmissionIds) {
+    }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/AdmissionService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/AdmissionService.java
@@ -107,14 +107,14 @@ public class AdmissionService {
     }
 
 
-    public void requestAdmissions(Group group, List<Long> requestAdmissionIds, Long userId) {
-        User reqUser = userUtils.getUserFromSecurityContext();
-        GroupUsers groupUsers = group.getGroupUsers();
-        groupUsers.validUserIsAlreadyEnterGroup(reqUser);
-
+    public List<Admission> requestAdmissions(Group group, List<Long> requestAdmissionIds, Long reqUserId) {
+        List<User> users = userUtils.findByIdIn(requestAdmissionIds);
         //TODO : 요청시 알림 넣어주기?
-        Admission admission = Admission.createAdmission(reqUser, group);
-        admissionRepository.save(admission);
 
+        List<Admission> admissionList = users.stream()
+            .map(user -> Admission.createAdmission(user, group))
+            .collect(Collectors.toList());
+        admissionRepository.saveAll(admissionList);
+        return admissionList;
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/AdmissionService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/AdmissionService.java
@@ -10,6 +10,7 @@ import io.github.depromeet.knockknockbackend.domain.group.exception.AdmissionNot
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.AdmissionInfoDto;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.AdmissionInfoListResponse;
 import io.github.depromeet.knockknockbackend.domain.user.domain.User;
+import io.github.depromeet.knockknockbackend.global.utils.security.SecurityUtils;
 import io.github.depromeet.knockknockbackend.global.utils.user.UserUtils;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -38,9 +39,9 @@ public class AdmissionService {
             .build();
     }
 
-    private void validReqUserIsGroupHost(Group group, User reqUser) {
+    private void validReqUserIsGroupHost(Group group, Long userId) {
         GroupUsers groupUsers = group.getGroupUsers();
-        groupUsers.validReqUserIsGroupHost(reqUser);
+        groupUsers.validReqUserIsGroupHost(userId);
     }
 
     /**
@@ -63,9 +64,9 @@ public class AdmissionService {
      * 방장이 요청상태가 PENDING 인 그룹 가입 요청을 가져옵니다.
      */
     public AdmissionInfoListResponse getAdmissions(Group group) {
+        Long userId = SecurityUtils.getCurrentUserId();
 
-        User reqUser = userUtils.getUserFromSecurityContext();
-        validReqUserIsGroupHost(group, reqUser);
+        validReqUserIsGroupHost(group, userId);
 
         List<Admission> Admissions = admissionRepository.findByGroupAndAdmissionState(group ,
             AdmissionState.PENDING);
@@ -82,8 +83,9 @@ public class AdmissionService {
      * 방장이 그룹 가입 요청을 승인합니다.
      */
     public AdmissionInfoDto acceptAdmission(Group group , Long admissionId) {
-        User reqUser = userUtils.getUserFromSecurityContext();
-        validReqUserIsGroupHost(group, reqUser);
+        Long reqUserId = SecurityUtils.getCurrentUserId();
+
+        validReqUserIsGroupHost(group, reqUserId);
 
         Admission admission = queryAdmission(admissionId);
         admission.acceptAdmission();
@@ -94,8 +96,9 @@ public class AdmissionService {
      * 방장이 그룹 가입 요청을 거절합니다.
      */
     public AdmissionInfoDto refuseAdmission(Group group , Long admissionId) {
-        User reqUser = userUtils.getUserFromSecurityContext();
-        validReqUserIsGroupHost(group, reqUser);
+        Long userId = SecurityUtils.getCurrentUserId();
+
+        validReqUserIsGroupHost(group, userId);
 
         Admission admission = queryAdmission(admissionId);
         admission.refuseAdmission();
@@ -104,7 +107,7 @@ public class AdmissionService {
     }
 
 
-    public void requestAdmissions(Group group, List<Long> requestAdmissionIds) {
+    public void requestAdmissions(Group group, List<Long> requestAdmissionIds, Long userId) {
         User reqUser = userUtils.getUserFromSecurityContext();
         GroupUsers groupUsers = group.getGroupUsers();
         groupUsers.validUserIsAlreadyEnterGroup(reqUser);

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/GroupService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/GroupService.java
@@ -6,7 +6,6 @@ import io.github.depromeet.knockknockbackend.domain.group.domain.Group.GroupBuil
 import io.github.depromeet.knockknockbackend.domain.group.domain.Category;
 import io.github.depromeet.knockknockbackend.domain.group.domain.GroupType;
 import io.github.depromeet.knockknockbackend.domain.group.domain.GroupUsers;
-import io.github.depromeet.knockknockbackend.domain.group.domain.InviteState;
 import io.github.depromeet.knockknockbackend.domain.group.domain.repository.CategoryRepository;
 import io.github.depromeet.knockknockbackend.domain.group.domain.repository.GroupRepository;
 import io.github.depromeet.knockknockbackend.domain.group.domain.repository.GroupUserRepository;

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/GroupService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/GroupService.java
@@ -336,11 +336,10 @@ public class GroupService {
         return getGroupBriefInfoListResponse(groupList);
     }
 
-    public GroupResponse addMembersToGroup(Long groupId, AddFriendToGroupRequest addFriendToGroupRequest) {
+    public GroupResponse addMembersToGroup(Long groupId, List<Long> requestMemberIds) {
         User reqUser = userUtils.getUserFromSecurityContext();
         Group group = queryGroup(groupId);
 
-        List<Long> requestMemberIds = addFriendToGroupRequest.getMemberIds();
         GroupUsers groupUsers = group.getGroupUsers();
         List<Long> groupUserIds = groupUsers.getUserIds();
 
@@ -350,7 +349,7 @@ public class GroupService {
 
         List<User> findUserList = userUtils.findByIdIn(requestMemberIds);
         // 요청받은 유저 아이디 목록이 디비에 존재하는 지 확인
-        validReqMemberNotExist(findUserList, addFriendToGroupRequest.getMemberIds());
+        validReqMemberNotExist(findUserList, requestMemberIds);
 
         groupUsers.addMembers(findUserList ,group);
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/GroupService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/GroupService.java
@@ -5,7 +5,6 @@ import io.github.depromeet.knockknockbackend.domain.group.domain.Group;
 import io.github.depromeet.knockknockbackend.domain.group.domain.Group.GroupBuilder;
 import io.github.depromeet.knockknockbackend.domain.group.domain.Category;
 import io.github.depromeet.knockknockbackend.domain.group.domain.GroupType;
-import io.github.depromeet.knockknockbackend.domain.group.domain.GroupUser;
 import io.github.depromeet.knockknockbackend.domain.group.domain.GroupUsers;
 import io.github.depromeet.knockknockbackend.domain.group.domain.repository.CategoryRepository;
 import io.github.depromeet.knockknockbackend.domain.group.domain.repository.GroupRepository;
@@ -13,7 +12,6 @@ import io.github.depromeet.knockknockbackend.domain.group.domain.repository.Grou
 import io.github.depromeet.knockknockbackend.domain.group.exception.CategoryNotFoundException;
 import io.github.depromeet.knockknockbackend.domain.group.exception.GroupNotFoundException;
 import io.github.depromeet.knockknockbackend.domain.group.exception.HostCanNotLeaveGroupException;
-import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.request.AddFriendToGroupRequest;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.request.CreateFriendGroupRequest;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.request.CreateOpenGroupRequest;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.request.GroupInTypeRequest;
@@ -21,11 +19,11 @@ import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.reque
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.CreateGroupResponse;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.GroupBriefInfoDto;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.GroupBriefInfoListResponse;
+import io.github.depromeet.knockknockbackend.global.utils.security.SecurityUtils;
 import io.github.depromeet.knockknockbackend.global.utils.user.UserUtils;
 import io.github.depromeet.knockknockbackend.domain.group.presentation.dto.response.GroupResponse;
 import io.github.depromeet.knockknockbackend.domain.user.domain.User;
 import io.github.depromeet.knockknockbackend.global.exception.UserNotFoundException;
-import io.github.depromeet.knockknockbackend.global.utils.security.SecurityUtils;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -200,13 +198,13 @@ public class GroupService {
      * @return GroupResponse
      */
     public GroupResponse updateGroup(Long groupId , UpdateGroupRequest updateGroupRequest) {
+        Long reqUserId = SecurityUtils.getCurrentUserId();
         Group group = queryGroup(groupId);
-        User reqUser = userUtils.getUserFromSecurityContext();
 
         // 그룹 유저 일급 컬랙션
         GroupUsers groupUsers = group.getGroupUsers();
         // reqUser 가 호스트인지 확인하는 메서드
-        groupUsers.validReqUserIsGroupHost(reqUser);
+        groupUsers.validReqUserIsGroupHost(reqUserId);
         Category category = queryGroupCategoryById(updateGroupRequest.getCategoryId());
         group.updateGroup(updateGroupRequest.toUpdateGroupDto(), category);
 
@@ -222,11 +220,13 @@ public class GroupService {
      * @param groupId
      */
     public void deleteGroup(Long groupId) {
+        Long reqUserId = SecurityUtils.getCurrentUserId();
+
         Group group = queryGroup(groupId);
         User reqUser = userUtils.getUserFromSecurityContext();
         GroupUsers groupUsers = group.getGroupUsers();
 
-        groupUsers.validReqUserIsGroupHost(reqUser);
+        groupUsers.validReqUserIsGroupHost(reqUserId);
 
         // 캐스케이드 타입 all로 줬습니다.!
         // 그룹지우면 그룹유저 미들 테이블 삭제됩니다.
@@ -239,11 +239,12 @@ public class GroupService {
      * @return GroupResponse
      */
     public GroupResponse getGroupDetailById(Long groupId) {
+        Long reqUserId = SecurityUtils.getCurrentUserId();
+
         Group group = queryGroup(groupId);
-        User reqUser = userUtils.getUserFromSecurityContext();
         GroupUsers groupUsers = group.getGroupUsers();
 
-        Boolean iHost = groupUsers.checkReqUserGroupHost(reqUser);
+        Boolean iHost = groupUsers.checkReqUserGroupHost(reqUserId);
 
         return new GroupResponse(
             group.getGroupBaseInfoVo(),
@@ -336,41 +337,33 @@ public class GroupService {
         return getGroupBriefInfoListResponse(groupList);
     }
 
-    public GroupResponse addMembersToGroup(Long groupId, List<Long> requestMemberIds) {
-        User reqUser = userUtils.getUserFromSecurityContext();
-        Group group = queryGroup(groupId);
+    public GroupResponse addMembersToGroup(Group group, List<Long> requestMemberIds, Long userId) {
+        Long reqUserId = SecurityUtils.getCurrentUserId();
 
         GroupUsers groupUsers = group.getGroupUsers();
-        List<Long> groupUserIds = groupUsers.getUserIds();
-
-        requestMemberIds.removeIf(groupUserIds::contains);
-
-        groupUsers.validReqUserIsGroupHost(reqUser);
-
         List<User> findUserList = userUtils.findByIdIn(requestMemberIds);
-        // 요청받은 유저 아이디 목록이 디비에 존재하는 지 확인
-        validReqMemberNotExist(findUserList, requestMemberIds);
-
         groupUsers.addMembers(findUserList ,group);
-
-        return new GroupResponse(group.getGroupBaseInfoVo(),groupUsers.getUserInfoVoList(),true);
+        return new GroupResponse(group.getGroupBaseInfoVo(),
+            groupUsers.getUserInfoVoList(),
+            groupUsers.checkReqUserGroupHost(reqUserId));
     }
 
     public GroupResponse deleteMemberFromGroup(Long groupId, Long userId) {
-        User reqUser = userUtils.getUserFromSecurityContext();
+        Long reqUserId = SecurityUtils.getCurrentUserId();
+
         Group group = queryGroup(groupId);
         GroupUsers groupUsers = group.getGroupUsers();
 
         // 일반 유저가 본인 스스로 방에서 나갈때
-        if(reqUser.getId().equals(userId)){
-            if(groupUsers.checkReqUserGroupHost(reqUser))
+        if(reqUserId.equals(userId)){
+            if(groupUsers.checkReqUserGroupHost(reqUserId))
                 throw HostCanNotLeaveGroupException.EXCEPTION;
             groupUsers.removeUserByUserId(userId);
             return new GroupResponse(group.getGroupBaseInfoVo(),groupUsers.getUserInfoVoList(),false);
         }
 
         // 방장의 권한으로 내쫓을때
-        groupUsers.validReqUserIsGroupHost(reqUser);
+        groupUsers.validReqUserIsGroupHost(reqUserId);
         groupUsers.removeUserByUserId(userId);
         return new GroupResponse(group.getGroupBaseInfoVo(),groupUsers.getUserInfoVoList(),true);
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/GroupService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/GroupService.java
@@ -341,7 +341,9 @@ public class GroupService {
         Long reqUserId = SecurityUtils.getCurrentUserId();
 
         GroupUsers groupUsers = group.getGroupUsers();
+        // 친구 리스트 찾은거에 유저 캐시 포함되어서 크게 차인 없을듯...?
         List<User> findUserList = userUtils.findByIdIn(requestMemberIds);
+
         groupUsers.addMembers(findUserList ,group);
         return new GroupResponse(group.getGroupBaseInfoVo(),
             groupUsers.getUserInfoVoList(),

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/GroupService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/GroupService.java
@@ -342,10 +342,6 @@ public class GroupService {
         return getGroupBriefInfoListResponse(groupList);
     }
 
-    public GroupResponse addMembersToGroup(Group group, List<Long> requestMemberIds, Long userId) {
-
-    }
-
     public GroupResponse addMembersToGroup(Long groupId, List<Long> requestMemberIds) {
         Long reqUserId = SecurityUtils.getCurrentUserId();
 
@@ -357,23 +353,22 @@ public class GroupService {
 
         List<Long> myFriendList = relationUtils.findMyFriendUserIdList(reqUserId);
 
-        //요청한 목록 중에서 내 친구 아닌 사람
+        // 그룹이 오픈 그룹이면
         // 초대 요청 보내기
         if(group.getGroupType().equals(GroupType.OPEN)){
-            List<Long> sendInviteUserIds = requestMemberIds.stream().filter(id ->
-                !myFriendList.contains(id)
-            ).collect(Collectors.toList());
-            inviteService.makeInvites(group ,sendInviteUserIds , reqUserId);
+            List<Long> sendInviteUserIds = requestMemberIds.stream()
+                .filter(id -> !myFriendList.contains(id))
+                .collect(Collectors.toList());
+            inviteService.makeInvites(group ,sendInviteUserIds);
         }
 
         //요청한 목록 중에서 내 친구 인 사람
-        List<Long> addMemberList = requestMemberIds.stream().filter(id ->
-            myFriendList.contains(id)
-        ).collect(Collectors.toList());
+        List<Long> addMemberList = requestMemberIds.stream()
+            .filter(myFriendList::contains)
+            .collect(Collectors.toList());
 
         List<User> findUserList = userUtils.findByIdIn(addMemberList);
         // 내 친구 목록에 있는 사람들은 그냥 방안에 넣기
-
         groupUsers.addMembers(findUserList ,group);
         return new GroupResponse(group.getGroupBaseInfoVo(),
             groupUsers.getUserInfoVoList(),

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/InviteService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/InviteService.java
@@ -46,6 +46,8 @@ public class InviteService {
     public Invite acceptInvite(Long inviteId){
         Invite invite = queryInvite(inviteId);
         invite.acceptInvite();
+        //TODO: 멤버 추가 해줘야함
+
         return invite;
     }
     public Invite refuseInvite(Long inviteId){

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/InviteService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/InviteService.java
@@ -1,0 +1,12 @@
+package io.github.depromeet.knockknockbackend.domain.group.service;
+
+import io.github.depromeet.knockknockbackend.domain.group.domain.repository.InviteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InviteService {
+
+    private final InviteRepository inviteRepository;
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/InviteService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/InviteService.java
@@ -1,17 +1,56 @@
 package io.github.depromeet.knockknockbackend.domain.group.service;
 
 import io.github.depromeet.knockknockbackend.domain.group.domain.Group;
+import io.github.depromeet.knockknockbackend.domain.group.domain.Invite;
 import io.github.depromeet.knockknockbackend.domain.group.domain.repository.InviteRepository;
+import io.github.depromeet.knockknockbackend.domain.group.exception.InviteNotFoundException;
+import io.github.depromeet.knockknockbackend.domain.user.domain.User;
+import io.github.depromeet.knockknockbackend.global.utils.user.UserUtils;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class InviteService {
 
     private final InviteRepository inviteRepository;
 
-    public void makeInvites(Group group, List<Long> sendInviteUserIds, Long reqUserId) {
+    private final UserUtils userUtils;
+
+    public Invite queryInvite(Long inviteId) {
+        return inviteRepository.findById(inviteId)
+            .orElseThrow(() -> InviteNotFoundException.EXCEPTION);
+    }
+
+    public List<Invite> makeInvites(Group group, List<Long> requestAdmissionIds) {
+        List<User> users = userUtils.findByIdIn(requestAdmissionIds);
+        User reqUser = userUtils.getUserFromSecurityContext();
+        //TODO : 요청시 알림 넣어주기?
+
+        List<Invite> admissionList = users.stream()
+            .map(user -> Invite.createInvite(user,reqUser, group))
+            .collect(Collectors.toList());
+        inviteRepository.saveAll(admissionList);
+
+        return admissionList;
+    }
+
+    // 다른 도메인에서 호출 할 메소드들...?
+    public Invite findInviteById(Long inviteId){
+        return queryInvite(inviteId);
+    }
+    public Invite acceptInvite(Long inviteId){
+        Invite invite = queryInvite(inviteId);
+        invite.acceptInvite();
+        return invite;
+    }
+    public Invite refuseInvite(Long inviteId){
+        Invite invite = queryInvite(inviteId);
+        invite.refuseInvite();
+        return invite;
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/InviteService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/service/InviteService.java
@@ -1,6 +1,8 @@
 package io.github.depromeet.knockknockbackend.domain.group.service;
 
+import io.github.depromeet.knockknockbackend.domain.group.domain.Group;
 import io.github.depromeet.knockknockbackend.domain.group.domain.repository.InviteRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,4 +11,7 @@ import org.springframework.stereotype.Service;
 public class InviteService {
 
     private final InviteRepository inviteRepository;
+
+    public void makeInvites(Group group, List<Long> sendInviteUserIds, Long reqUserId) {
+    }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
 
     ALREADY_GROUP_ENTER(400 , "GROUP-400-3","Already enter group"),
     ADMISSION_NOT_FOUND(404,"GROUP-404-4", "ADMISSION Not Found"),
+    INVITE_NOT_FOUND(404,"GROUP-404-5", "INVITE Not Found"),
 
     HOST_CAN_NOT_LEAVE(400 , "GROUP-400-2","Host can not leave from own group" );
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/relation/RelationUtils.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/relation/RelationUtils.java
@@ -1,5 +1,7 @@
 package io.github.depromeet.knockknockbackend.global.utils.relation;
 
-public interface RelationUtils {
+import java.util.List;
 
+public interface RelationUtils {
+    List<Long> findMyFriendUserIdList(Long myId);
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/relation/RelationUtils.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/relation/RelationUtils.java
@@ -1,0 +1,5 @@
+package io.github.depromeet.knockknockbackend.global.utils.relation;
+
+public interface RelationUtils {
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/relation/RelationUtilsImpl.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/relation/RelationUtilsImpl.java
@@ -1,0 +1,33 @@
+package io.github.depromeet.knockknockbackend.global.utils.relation;
+
+
+import io.github.depromeet.knockknockbackend.domain.relation.domain.Relation;
+import io.github.depromeet.knockknockbackend.domain.relation.domain.repository.RelationRepository;
+import io.github.depromeet.knockknockbackend.domain.user.domain.User;
+import io.github.depromeet.knockknockbackend.global.utils.security.SecurityUtils;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RelationUtilsImpl {
+
+    private final RelationRepository relationRepository;
+
+    public List<Long> findMyFriendUserIdList(Long myId){
+        List<Relation> relationList = relationRepository.findFriendList(SecurityUtils.getCurrentUserId());
+
+        List<Long> result = relationList.stream().map(
+            relation -> {
+                if(relation.getReceiveUser().getId().equals(myId)) {
+                    return relation.getSendUser().getId();
+                } else {
+                    return relation.getReceiveUser().getId();
+                }
+            }
+        ).filter(userId -> userId.equals(myId)).collect(Collectors.toList());
+        return result;
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/relation/RelationUtilsImpl.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/relation/RelationUtilsImpl.java
@@ -3,7 +3,6 @@ package io.github.depromeet.knockknockbackend.global.utils.relation;
 
 import io.github.depromeet.knockknockbackend.domain.relation.domain.Relation;
 import io.github.depromeet.knockknockbackend.domain.relation.domain.repository.RelationRepository;
-import io.github.depromeet.knockknockbackend.domain.user.domain.User;
 import io.github.depromeet.knockknockbackend.global.utils.security.SecurityUtils;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -12,7 +11,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class RelationUtilsImpl {
+public class RelationUtilsImpl implements RelationUtils{
 
     private final RelationRepository relationRepository;
 


### PR DESCRIPTION
 - 친구 목록이 필요해서 글로벌 쪽에 relationUtil 두었습니다.!
 서준님 친구관계 서비스 작업중이신거같아서 일단은 글로벌쪽에 넣었습니당

 - 초대 엔티티를 추가했습니다.
 - userId만 필요한 로직들은 디비에서 user를 불러오는것이아닌 시큐리티콘텍스트에서 불러온
 userId가지고 수행하도록 수정했습니다


- 초대, 가입 요청 승인 로직은 다음 이슈로 넘기겠습니다...
admissionFacade를 없애도 될것 같아서 그렇게 처리해보겠습니다.


close #75 