### PR TITLE
🔀 :: (#80) FCM 즉시 알림 전송 구현

### DIFF
--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/Group.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/group/domain/Group.java
@@ -56,8 +56,9 @@ public class Group extends BaseTimeEntity {
 
 
     @Builder
-    public Group(String title, String description, String thumbnailPath, String backgroundImagePath,
+    public Group(Long id, String title, String description, String thumbnailPath, String backgroundImagePath,
         Boolean publicAccess , Category category ,GroupType groupType) {
+        this.id = id;
         this.title = title;
         this.description = description;
         this.thumbnailPath = thumbnailPath;
@@ -95,5 +96,11 @@ public class Group extends BaseTimeEntity {
 
     public int getMemberCount(){
         return this.groupUsers.getMemberCount();
+    }
+
+    public static Group of(Long id) {
+        return Group.builder()
+            .id(id)
+            .build();
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/DeviceToken.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/DeviceToken.java
@@ -1,11 +1,15 @@
 package io.github.depromeet.knockknockbackend.domain.notification.domain;
 
+import io.github.depromeet.knockknockbackend.domain.user.domain.User;
 import io.github.depromeet.knockknockbackend.global.database.BaseTimeEntity;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -25,7 +29,9 @@ public class DeviceToken extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long userId;
+    @JoinColumn(name = "user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
 
     private String deviceId;
 
@@ -35,7 +41,7 @@ public class DeviceToken extends BaseTimeEntity {
 
     public static DeviceToken of(Long userId, String deviceId, String deviceToken) {
         return DeviceToken.builder()
-            .userId(userId)
+            .user(User.of(userId))
             .deviceId(deviceId)
             .token(deviceToken)
             .build();

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/DeviceToken.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/DeviceToken.java
@@ -38,6 +38,9 @@ public class DeviceToken extends BaseTimeEntity {
     @Column(unique = true)
     private String token;
 
+    public Long getUserId() {
+        return this.user.getId();
+    }
 
     public static DeviceToken of(Long userId, String deviceId, String deviceToken) {
         return DeviceToken.builder()

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/NightCondition.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/NightCondition.java
@@ -14,11 +14,7 @@ public enum NightCondition {
 
     public static boolean isNight() {
         int nowHour = LocalDateTime.now().getHour();
-        if (nowHour >= NightCondition.START_TIME.hour ||
-            nowHour < NightCondition.END_TIME.hour) {
-            return true;
-        }
-        return false;
+        return nowHour >= NightCondition.START_TIME.hour || nowHour < NightCondition.END_TIME.hour;
     }
 
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/NightCondition.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/NightCondition.java
@@ -1,5 +1,7 @@
 package io.github.depromeet.knockknockbackend.domain.notification.domain;
 
+import java.time.LocalDateTime;
+
 public enum NightCondition {
     START_TIME(21),
     END_TIME(8);
@@ -10,7 +12,13 @@ public enum NightCondition {
         this.hour = hour;
     }
 
-    public int getHour() {
-        return hour;
+    public static boolean isNight() {
+        int nowHour = LocalDateTime.now().getHour();
+        if (nowHour >= NightCondition.START_TIME.hour ||
+            nowHour < NightCondition.END_TIME.hour) {
+            return true;
+        }
+        return false;
     }
+
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/NightCondition.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/NightCondition.java
@@ -1,0 +1,16 @@
+package io.github.depromeet.knockknockbackend.domain.notification.domain;
+
+public enum NightCondition {
+    START_TIME(21),
+    END_TIME(8);
+
+    private final int hour;
+
+    NightCondition(int hour) {
+        this.hour = hour;
+    }
+
+    public int getHour() {
+        return hour;
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/Notification.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/Notification.java
@@ -2,8 +2,8 @@ package io.github.depromeet.knockknockbackend.domain.notification.domain;
 
 import io.github.depromeet.knockknockbackend.domain.group.domain.Group;
 import io.github.depromeet.knockknockbackend.domain.user.domain.User;
+import io.github.depromeet.knockknockbackend.global.database.BaseTimeEntity;
 import java.time.LocalDateTime;
-import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -26,7 +26,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "tbl_notification")
 @Entity
-public class Notification {
+public class Notification extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,9 +37,6 @@ public class Notification {
     private String content;
 
     private String imageUrl;
-
-    @Convert(converter = AlarmTypeConverter.class)
-    private AlarmType alarmType;
 
     @JoinColumn(name = "group_id")
     @ManyToOne(fetch = FetchType.LAZY)
@@ -53,5 +50,14 @@ public class Notification {
     @OneToOne(fetch = FetchType.LAZY)
     private User receiveUser;
 
+    public static Notification of(String content, String imageUrl, Group group, User sendUser, LocalDateTime sendAt){
+        return Notification.builder()
+            .content(content)
+            .imageUrl(imageUrl)
+            .group(group)
+            .sendUser(sendUser)
+            .sendAt(sendAt)
+            .build();
+    }
 
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/Notification.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/Notification.java
@@ -34,6 +34,8 @@ public class Notification extends BaseTimeEntity {
 
     private LocalDateTime sendAt;
 
+    private String title;
+
     private String content;
 
     private String imageUrl;
@@ -50,8 +52,9 @@ public class Notification extends BaseTimeEntity {
     @OneToOne(fetch = FetchType.LAZY)
     private User receiveUser;
 
-    public static Notification of(String content, String imageUrl, Group group, User sendUser, LocalDateTime sendAt){
+    public static Notification of(String title, String content, String imageUrl, Group group, User sendUser, LocalDateTime sendAt){
         return Notification.builder()
+            .title(title)
             .content(content)
             .imageUrl(imageUrl)
             .group(group)

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/repository/DeviceTokenRepository.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/repository/DeviceTokenRepository.java
@@ -1,10 +1,27 @@
 package io.github.depromeet.knockknockbackend.domain.notification.domain.repository;
 
 import io.github.depromeet.knockknockbackend.domain.notification.domain.DeviceToken;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface DeviceTokenRepository extends CrudRepository<DeviceToken, Long> {
     Optional<DeviceToken> findByDeviceId(String deviceId);
+
+    @Query("select DT "
+        + "from DeviceToken DT "
+        + "where DT.user.id in "
+        + "(select GU.user.id "
+        + "from GroupUser GU "
+        + "join Option O "
+        + "on GU.user.id = O.user.id "
+        + "where GU.group.id = :groupId "
+        + "and O.newOption = :newOption "
+        + "AND (coalesce(:nightOption, NULL) IS NULL OR O.nightOption = :nightOption))")
+    List<DeviceToken> findUserByGroupIdAndNewOption(@Param("groupId") Long groupId,
+        @Param("newOption") Boolean newOption,
+        @Param("nightOption") Boolean nightOption);
 
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/exception/FcmResponseException.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/exception/FcmResponseException.java
@@ -1,0 +1,12 @@
+package io.github.depromeet.knockknockbackend.domain.notification.exception;
+
+import io.github.depromeet.knockknockbackend.global.error.exception.ErrorCode;
+import io.github.depromeet.knockknockbackend.global.error.exception.KnockException;
+
+public class FcmResponseException extends KnockException {
+    public static final KnockException EXCEPTION = new FcmResponseException();
+
+    public FcmResponseException() {
+        super(ErrorCode.NOTIFICATION_FCM_FAIL_SEND);
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/exception/FcmResponseException.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/exception/FcmResponseException.java
@@ -6,7 +6,7 @@ import io.github.depromeet.knockknockbackend.global.error.exception.KnockExcepti
 public class FcmResponseException extends KnockException {
     public static final KnockException EXCEPTION = new FcmResponseException();
 
-    public FcmResponseException() {
+    private FcmResponseException() {
         super(ErrorCode.NOTIFICATION_FCM_FAIL_SEND);
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
@@ -11,11 +11,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @SecurityRequirement(name = "access-token")
@@ -33,16 +33,16 @@ public class NotificationController {
         return notificationService.queryAlarmHistoryByUserId(pageable);
     }
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/token")
-    public ResponseEntity<Void> registerFcmToken(@RequestBody RegisterFcmTokenRequest request) {
+    public void registerFcmToken(@RequestBody RegisterFcmTokenRequest request) {
         notificationService.registerFcmToken(request);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/instance")
-    public ResponseEntity<Void> sendInstance(@RequestBody SendInstanceRequest request) {
+    public void sendInstance(@RequestBody SendInstanceRequest request) {
         notificationService.sendInstance(request);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
@@ -1,6 +1,7 @@
 package io.github.depromeet.knockknockbackend.domain.notification.presentation;
 
 import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.request.RegisterFcmTokenRequest;
+import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.request.SendInstanceRequest;
 import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryAlarmHistoryResponse;
 import io.github.depromeet.knockknockbackend.domain.notification.service.NotificationService;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -37,5 +38,12 @@ public class NotificationController {
         notificationService.registerFcmToken(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+    @PostMapping("/instance")
+    public ResponseEntity<Void> sendInstance(@RequestBody SendInstanceRequest request) {
+        notificationService.sendInstance(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
 
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/request/SendInstanceRequest.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/request/SendInstanceRequest.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public class SendInstanceRequest {
 
     private Long groupId;
+    private String title;
     private String content;
     private String imageUrl;
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/request/SendInstanceRequest.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/dto/request/SendInstanceRequest.java
@@ -1,0 +1,12 @@
+package io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class SendInstanceRequest {
+
+    private Long groupId;
+    private String content;
+    private String imageUrl;
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -92,7 +92,7 @@ public class NotificationService {
             }
         } catch (FirebaseMessagingException e) {
             log.error("[**FCM notification sending Error] {} ", e.getMessage());
-            throw new FcmResponseException();
+            throw FcmResponseException.EXCEPTION;
         }
 
         notificationRepository.save(Notification.of(request.getTitle(), request.getContent(), request.getImageUrl(),
@@ -109,7 +109,7 @@ public class NotificationService {
                 sendResponse.getException().getErrorCode(),
                 sendResponse.getException().getMessage()));
 
-        throw new FcmResponseException();
+        throw FcmResponseException.EXCEPTION;
     }
 
     private MulticastMessage makeMulticastMessageForFcm(SendInstanceRequest request, List<String> tokens) {

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -116,6 +116,7 @@ public class NotificationService {
         return MulticastMessage.builder()
             .setNotification(
                 com.google.firebase.messaging.Notification.builder()
+                    .setTitle(request.getTitle())
                     .setBody(request.getContent())
                     .setImage(request.getImageUrl())
                     .build())

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -106,7 +106,8 @@ public class NotificationService {
     private void handleFcmMessagingException(BatchResponse batchResponse) {
         log.error(
             "[**FCM notification sending Error] successCount : {}, failureCount : {} ",
-            batchResponse.getSuccessCount(), batchResponse.getFailureCount());
+            batchResponse.getSuccessCount(), batchResponse.getFailureCount()
+        );
         batchResponse.getResponses()
             .forEach(
                 sendResponse -> log.error(

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -95,8 +95,12 @@ public class NotificationService {
             throw FcmResponseException.EXCEPTION;
         }
 
-        notificationRepository.save(Notification.of(request.getTitle(), request.getContent(), request.getImageUrl(),
-            Group.of(request.getGroupId()), User.of(sendUserId), LocalDateTime.now()));
+        notificationRepository.save(
+            Notification.of(
+                request.getTitle(), request.getContent(), request.getImageUrl(),
+                Group.of(request.getGroupId()), User.of(sendUserId), LocalDateTime.now()
+            )
+        );
     }
 
     private void handleFcmMessagingException(BatchResponse batchResponse) {
@@ -104,15 +108,19 @@ public class NotificationService {
             "[**FCM notification sending Error] successCount : {}, failureCount : {} ",
             batchResponse.getSuccessCount(), batchResponse.getFailureCount());
         batchResponse.getResponses()
-            .forEach(sendResponse -> log.error(
-                "[**FCM notification sending Error] errorCode: {}, errorMessage : {}",
-                sendResponse.getException().getErrorCode(),
-                sendResponse.getException().getMessage()));
+            .forEach(
+                sendResponse -> log.error(
+                    "[**FCM notification sending Error] errorCode: {}, errorMessage : {}",
+                    sendResponse.getException().getErrorCode(),
+                    sendResponse.getException().getMessage()
+                )
+            );
 
         throw FcmResponseException.EXCEPTION;
     }
 
-    private MulticastMessage makeMulticastMessageForFcm(SendInstanceRequest request, List<String> tokens) {
+    private MulticastMessage makeMulticastMessageForFcm(SendInstanceRequest request,
+        List<String> tokens) {
         return MulticastMessage.builder()
             .setNotification(
                 com.google.firebase.messaging.Notification.builder()
@@ -125,7 +133,8 @@ public class NotificationService {
     }
 
     private List<String> getTokens(SendInstanceRequest request, Long sendUserId) {
-        List<DeviceToken> deviceTokens = getDeviceTokensOfGroupUserSettingAlarm(request.getGroupId());
+        List<DeviceToken> deviceTokens = getDeviceTokensOfGroupUserSettingAlarm(
+            request.getGroupId());
 
         return deviceTokens.stream()
             .filter(deviceToken -> !deviceToken.getUserId().equals(sendUserId))

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -49,7 +49,7 @@ public class NotificationService {
 
         deviceTokenOptional.ifPresentOrElse(
             deviceToken -> {
-                if (deviceToken.getUserId().equals(currentUserId)) {
+                if (deviceToken.getUser().getId().equals(currentUserId)) {
                     deviceTokenRepository.save(
                         deviceToken.changeToken(request.getToken()));
                 } else {

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -133,10 +133,8 @@ public class NotificationService {
     }
 
     private List<DeviceToken> getDeviceTokensOfGroupUserSettingAlarm(Long groupId) {
-        int hour = LocalDateTime.now().getHour();
         Boolean nightOption = null;
-        if (hour >= NightCondition.START_TIME.getHour() &&
-            hour < NightCondition.END_TIME.getHour()) {
+        if (NightCondition.isNight()) {
             nightOption = true;
         }
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -95,7 +95,7 @@ public class NotificationService {
             throw new FcmResponseException();
         }
 
-        notificationRepository.save(Notification.of(request.getContent(), request.getImageUrl(),
+        notificationRepository.save(Notification.of(request.getTitle(), request.getContent(), request.getImageUrl(),
             Group.of(request.getGroupId()), User.of(sendUserId), LocalDateTime.now()));
     }
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/service/NotificationService.java
@@ -62,7 +62,7 @@ public class NotificationService {
 
         deviceTokenOptional.ifPresentOrElse(
             deviceToken -> {
-                if (deviceToken.getUser().getId().equals(currentUserId)) {
+                if (deviceToken.getUserId().equals(currentUserId)) {
                     deviceTokenRepository.save(
                         deviceToken.changeToken(request.getToken()));
                 } else {
@@ -128,7 +128,7 @@ public class NotificationService {
         List<DeviceToken> deviceTokens = getDeviceTokensOfGroupUserSettingAlarm(request.getGroupId());
 
         return deviceTokens.stream()
-            .filter(deviceToken -> !deviceToken.getUser().getId().equals(sendUserId))
+            .filter(deviceToken -> !deviceToken.getUserId().equals(sendUserId))
             .map(DeviceToken::getToken)
             .collect(Collectors.toList());
     }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/User.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/User.java
@@ -35,18 +35,26 @@ public class User {
     private String profilePath;
 
     @Builder
-    public User(String nickname, String oauthProvider, String oauthId , String email) {
+    public User(Long id, String nickname, String oauthProvider, String oauthId , String email) {
+        this.id = id;
         this.nickname = nickname;
         this.oauthProvider = oauthProvider;
         this.oauthId = oauthId;
         this.email = email;
     }
+
     public UserInfoVO getUserInfo() {
         return new UserInfoVO(id, nickname, profilePath);
     }
 
     public void changeNickname(String nickname) {
         this.nickname = nickname;
+    }
+
+    public static User of(Long userId) {
+        return User.builder()
+            .id(userId)
+            .build();
     }
 
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
@@ -39,7 +39,9 @@ public enum ErrorCode {
     ALREADY_GROUP_ENTER(400 , "GROUP-400-3","Already enter group"),
     ADMISSION_NOT_FOUND(404,"GROUP-404-4", "ADMISSION Not Found"),
 
-    HOST_CAN_NOT_LEAVE(400 , "GROUP-400-2","Host can not leave from own group" );
+    HOST_CAN_NOT_LEAVE(400 , "GROUP-400-2","Host can not leave from own group" ),
+
+    NOTIFICATION_FCM_FAIL_SEND(500 , "NOTIFICATION-500-1","Failed to send FCM notification message" );
 
 
 


### PR DESCRIPTION
### FCM 즉시 알림 전송 구현
- [X] 그룹(알림방) 내 사용자 중 알림 정보 ON한 token 조회, 야간 일 경우 야간 ON 정보만 추출
- [X] FCM multicastMessage로 알림 전송
- [X] 서비스 DB에 알림 전송 정보 저장.
	- notifciation 테이블에 받은 유저 1:N으로 저장되는 정보는 다음 PR에 반영 예정

### 참고 사항
- 처음 계획한 FCM 구독으로 처리하지 않고 알림 셋팅 정보 실시간 DB조회로 구현