### PR TITLE
🔀 :: (#138) 리액션 수정 API 리팩토링

### DIFF
--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/domain/repository/NotificationRepository.java
@@ -1,6 +1,7 @@
 package io.github.depromeet.knockknockbackend.domain.notification.domain.repository;
 
 import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/reaction/exception/ReactionAlreadyExistException.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/reaction/exception/ReactionAlreadyExistException.java
@@ -1,0 +1,12 @@
+package io.github.depromeet.knockknockbackend.domain.reaction.exception;
+
+import io.github.depromeet.knockknockbackend.global.error.exception.ErrorCode;
+import io.github.depromeet.knockknockbackend.global.error.exception.KnockException;
+
+public class ReactionAlreadyExistException extends KnockException {
+    public static final KnockException EXCEPTION = new ReactionAlreadyExistException();
+
+    private ReactionAlreadyExistException() {
+        super(ErrorCode.REACTION_ALREADY_EXIST);
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/reaction/presentation/ReactionController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/reaction/presentation/ReactionController.java
@@ -34,9 +34,10 @@ public class ReactionController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "알림에 리액션 수정")
-    @PatchMapping
-    public void changeReaction(@RequestBody RegisterReactionRequest request) {
-        reactionService.changeReaction(request);
+    @PatchMapping("{notification_reaction_id}")
+    public void changeReaction(@PathVariable("notification_reaction_id") Long notificationReactionId,
+        @RequestBody RegisterReactionRequest request) {
+        reactionService.changeReaction(notificationReactionId, request);
     }
 
     @ResponseStatus(HttpStatus.OK)

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/reaction/presentation/dto/request/RegisterReactionRequest.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/reaction/presentation/dto/request/RegisterReactionRequest.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 @Getter
 public class RegisterReactionRequest {
 
-    private Long notificationReactionId;
     private Long notificationId;
     private Long reactionId;
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/reaction/service/ReactionService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/reaction/service/ReactionService.java
@@ -3,6 +3,7 @@ package io.github.depromeet.knockknockbackend.domain.reaction.service;
 import io.github.depromeet.knockknockbackend.domain.notification.domain.Notification;
 import io.github.depromeet.knockknockbackend.domain.reaction.domain.NotificationReaction;
 import io.github.depromeet.knockknockbackend.domain.asset.domain.Reaction;
+import io.github.depromeet.knockknockbackend.domain.reaction.exception.ReactionAlreadyExistException;
 import io.github.depromeet.knockknockbackend.domain.reaction.exception.ReactionForbiddenException;
 import io.github.depromeet.knockknockbackend.domain.reaction.presentation.dto.request.RegisterReactionRequest;
 import io.github.depromeet.knockknockbackend.domain.reaction.domain.repository.NotificationReactionRepository;
@@ -21,12 +22,16 @@ public class ReactionService {
 
     @Transactional
     public void registerReaction(RegisterReactionRequest request) {
-        notificationReactionRepository.save(
-            NotificationReaction.of(
-                Notification.of(request.getNotificationId()),
-                Reaction.of(request.getReactionId()),
-                userUtils.getUserFromSecurityContext()
-            ));
+        try {
+            notificationReactionRepository.save(
+                NotificationReaction.of(
+                    Notification.of(request.getNotificationId()),
+                    Reaction.of(request.getReactionId()),
+                    userUtils.getUserFromSecurityContext()
+                ));
+        } catch(Exception e) {
+            throw ReactionAlreadyExistException.EXCEPTION;
+        }
     }
 
     public void changeReaction(Long notificationReactionId, RegisterReactionRequest request) {

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/reaction/service/ReactionService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/reaction/service/ReactionService.java
@@ -29,14 +29,12 @@ public class ReactionService {
             ));
     }
 
-    public void changeReaction(RegisterReactionRequest request) {
-        if (request.getNotificationReactionId() != null) {
-            validateMyReactionTheNotification(request.getNotificationReactionId());
-        }
+    public void changeReaction(Long notificationReactionId, RegisterReactionRequest request) {
+        validateMyReactionTheNotification(notificationReactionId);
 
         notificationReactionRepository.save(
             NotificationReaction.of(
-                request.getNotificationReactionId(),
+                notificationReactionId,
                 Reaction.of(request.getReactionId())
             ));
     }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
@@ -40,6 +40,8 @@ public enum ErrorCode {
     HOST_CAN_NOT_LEAVE(400 , "GROUP-400-2","Host can not leave from own group" ),
     NOT_GROUP_MEMBER(400 , "GROUP-400-3","Not member of group"),
     INVALID_INVITE_TOKEN(400 , "GROUP-400-4","invalid invite token"),
+
+    REACTION_ALREADY_EXIST(HttpStatus.BAD_REQUEST.value(),"REACTION-400-1" , "reaction of the notification is already exist"),
     REACTION_FORBIDDEN(HttpStatus.FORBIDDEN.value(), "REACTION-403-1", "the user cannot change the reaction"),
 
     NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN.value(), "NOTIFICATION-403-1", "The user has no access to the notification"),


### PR DESCRIPTION
- 리액션 수정 API 리팩토링
  - reactionId 받는 부분 request 객체에서 PathParameter로 변경
- 리액션 등록 시 해당하는 notificaiton에 리액션 등록시 커스텀 익셉션 발생