### PR TITLE
🔀 :: (#144) global 밸리데이션 에러 핸들링

### DIFF
--- a/src/main/java/io/github/depromeet/knockknockbackend/global/error/ErrorResponse.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/error/ErrorResponse.java
@@ -1,14 +1,24 @@
 package io.github.depromeet.knockknockbackend.global.error;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class ErrorResponse {
 
+    private final boolean success = false;
     private final int status;
     private final String code;
     private final String reason;
+    private final LocalDateTime timeStamp;
 
+    private final String path;
+    public ErrorResponse(int status, String code, String reason , String path) {
+        this.status = status;
+        this.code = code;
+        this.reason = reason;
+        this.timeStamp = LocalDateTime.now();
+        this.path = path;
+    }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/error/ExceptionFilter.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/error/ExceptionFilter.java
@@ -24,16 +24,16 @@ public class ExceptionFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (KnockException e) {
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            response.getWriter().write(objectMapper.writeValueAsString(getErrorResponse(e.getErrorCode())));
+            response.getWriter().write(objectMapper.writeValueAsString(getErrorResponse(e.getErrorCode(),request.getRequestURL().toString())));
         } catch (Exception e) {
             e.printStackTrace();
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-            getErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
+            getErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR,request.getRequestURL().toString());
         }
     }
 
-    private ErrorResponse getErrorResponse(ErrorCode errorCode) {
-        return new ErrorResponse(errorCode.getStatus(), errorCode.getCode(), errorCode.getReason());
+    private ErrorResponse getErrorResponse(ErrorCode errorCode , String path) {
+        return new ErrorResponse(errorCode.getStatus(), errorCode.getCode(), errorCode.getReason(),path);
     }
 
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/error/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import io.github.depromeet.knockknockbackend.global.error.exception.KnockExcepti
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,10 +13,19 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
-    //TODO : 밸리데이션 에러라던지 무언가 다른 응답이 필요한 에러항목들을... 바꿔주기!
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
+        ErrorCode validationError = ErrorCode.VALIDATION_ERROR;
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(validationError.getStatus(),
+                validationError.getCode(),
+                e.getMessage())
+            );
+    }
     @ExceptionHandler(KnockException.class)
-    public ResponseEntity<ErrorResponse> hanulExceptionHandler(KnockException e) {
+    public ResponseEntity<ErrorResponse> KnockExceptionHandler(KnockException e) {
         ErrorCode code = e.getErrorCode();
         return new ResponseEntity<>(new ErrorResponse(code.getStatus(), code.getCode(), code.getReason()),
             HttpStatus.valueOf(code.getStatus()));

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/error/GlobalExceptionHandler.java
@@ -1,10 +1,17 @@
 package io.github.depromeet.knockknockbackend.global.error;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.depromeet.knockknockbackend.global.error.exception.ErrorCode;
 import io.github.depromeet.knockknockbackend.global.error.exception.KnockException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javax.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -15,15 +22,25 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e) {
+    public ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e)
+        throws JsonProcessingException {
         ErrorCode validationError = ErrorCode.VALIDATION_ERROR;
+        List<FieldError> errors = e.getBindingResult().getFieldErrors();
+
+        Map<String, Object> fieldAndErrorMessages = errors.stream()
+            .collect(Collectors.toMap(
+                FieldError::getField, FieldError::getDefaultMessage)
+            );
+
+        String errorsToJsonString = new ObjectMapper().writeValueAsString(fieldAndErrorMessages);
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
             .body(new ErrorResponse(validationError.getStatus(),
                 validationError.getCode(),
-                e.getMessage())
+                errorsToJsonString)
             );
     }
+
     @ExceptionHandler(KnockException.class)
     public ResponseEntity<ErrorResponse> KnockExceptionHandler(KnockException e) {
         ErrorCode code = e.getErrorCode();

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/error/GlobalExceptionHandler.java
@@ -27,7 +27,7 @@ public class GlobalExceptionHandler {
         MethodArgumentNotValidException e,
         HttpServletRequest request
     ) throws JsonProcessingException {
-        ErrorCode validationError = ErrorCode.VALIDATION_ERROR;
+        ErrorCode validationError = ErrorCode.ARGUMENT_NOT_VALID_ERROR;
         List<FieldError> errors = e.getBindingResult().getFieldErrors();
 
         Map<String, Object> fieldAndErrorMessages = errors.stream()

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
 
     EXAMPLE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "EXAMPLE-404-1", "Example Not Found."),
 
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST.value(), "GLOBAL-400-1", "validation error"),
+
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "GLOBAL-401-1", "Expired Jwt Token."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "GLOBAL-401-1", "Invalid Jwt Token."),
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
@@ -10,7 +10,7 @@ public enum ErrorCode {
 
     EXAMPLE_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "EXAMPLE-404-1", "Example Not Found."),
 
-    VALIDATION_ERROR(HttpStatus.BAD_REQUEST.value(), "GLOBAL-400-1", "validation error"),
+    ARGUMENT_NOT_VALID_ERROR(HttpStatus.BAD_REQUEST.value(), "GLOBAL-400-1", "validation error"),
 
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "GLOBAL-401-1", "Expired Jwt Token."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "GLOBAL-401-1", "Invalid Jwt Token."),


### PR DESCRIPTION
```json
{
  "status": 400,
  "code": "GLOBAL-400-1",
  "reason": "{\"publicAccess\":\"asdfasdfdsafa\",\"description\":\"널이어서는 안됩니다\",\"title\":\"널이어서는 안됩니다\"}"
}
```
형식은 위처럼 맞췄습니당!

close #144 