### PR TITLE
🔀 :: (#20) global 성공응답 핸들링

### DIFF
--- a/src/main/java/io/github/depromeet/knockknockbackend/global/successResponse/SuccessResponse.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/successResponse/SuccessResponse.java
@@ -1,0 +1,19 @@
+package io.github.depromeet.knockknockbackend.global.successResponse;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class SuccessResponse {
+
+    private final boolean success = true;
+    private final int status;
+    private final Object data;
+    private final LocalDateTime timeStamp;
+
+    public SuccessResponse(int status, Object data) {
+        this.status = status;
+        this.data = data;
+        this.timeStamp = LocalDateTime.now();
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/successResponse/SuccessResponseAdvice.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/successResponse/SuccessResponseAdvice.java
@@ -1,5 +1,40 @@
 package io.github.depromeet.knockknockbackend.global.successResponse;
 
-public class SuccessResponseAdvice {
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
+@RestControllerAdvice
+public class SuccessResponseAdvice implements ResponseBodyAdvice {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body, MethodParameter returnType,
+        MediaType selectedContentType, Class selectedConverterType, ServerHttpRequest request,
+        ServerHttpResponse response) {
+        HttpServletResponse servletResponse = ((ServletServerHttpResponse) response).getServletResponse();
+
+        int status = servletResponse.getStatus();
+        HttpStatus resolve = HttpStatus.resolve(status);
+
+        if (resolve == null) {
+            return body;
+        }
+
+        if(resolve.is2xxSuccessful()){
+            return new SuccessResponse(status,body);
+        }
+
+        return body;
+    }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/successResponse/SuccessResponseAdvice.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/successResponse/SuccessResponseAdvice.java
@@ -1,0 +1,5 @@
+package io.github.depromeet.knockknockbackend.global.successResponse;
+
+public class SuccessResponseAdvice {
+
+}


### PR DESCRIPTION
 - 공통으로 성공응답처리

인터셉터 달까 하다가
서블릿에선 request response 한번밖에 못까서 복잡해질려던 찰나

ResponseBodyAdvice 이거 있어서 이걸로 해결했습니다
200 번대 성공응답 판단해주고싶었는데
```java
HttpStatus resolve = HttpStatus.resolve(status);
resolve.is2xxSuccessful()
```
위 HttpStatus에 메소드 있어서 신나게 만들어줬습니다.

단점은 스웨거에 안뜨긴하지만
이부분 규일님께 전달해드렸습니당

close #20 