### PR TITLE
🔀 :: (#78) 스웨거 customize , 앱 버젼체크

### DIFF
--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/domain/AppVersion.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/domain/AppVersion.java
@@ -1,2 +1,19 @@
-package io.github.depromeet.knockknockbackend.domain.asset.domain;public class AppVersion {
+package io.github.depromeet.knockknockbackend.domain.asset.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Table(name = "tbl_app_version")
+@Entity
+public class AppVersion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String version;
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/domain/AppVersion.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/domain/AppVersion.java
@@ -1,0 +1,2 @@
+package io.github.depromeet.knockknockbackend.domain.asset.domain;public class AppVersion {
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/domain/repository/AppVersionRepository.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/domain/repository/AppVersionRepository.java
@@ -1,0 +1,2 @@
+package io.github.depromeet.knockknockbackend.domain.asset.domain.repository;public interface AppVersionRepository {
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/domain/repository/AppVersionRepository.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/domain/repository/AppVersionRepository.java
@@ -1,2 +1,8 @@
-package io.github.depromeet.knockknockbackend.domain.asset.domain.repository;public interface AppVersionRepository {
+package io.github.depromeet.knockknockbackend.domain.asset.domain.repository;
+
+import io.github.depromeet.knockknockbackend.domain.asset.domain.AppVersion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppVersionRepository  extends JpaRepository<AppVersion, Long> {
+
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/exception/AppVersionNotFoundException.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/exception/AppVersionNotFoundException.java
@@ -3,12 +3,12 @@ package io.github.depromeet.knockknockbackend.domain.asset.exception;
 import io.github.depromeet.knockknockbackend.global.error.exception.ErrorCode;
 import io.github.depromeet.knockknockbackend.global.error.exception.KnockException;
 
-public class BackgroundImageNotFoundException extends KnockException {
+public class AppVersionNotFoundException extends KnockException {
 
-    public static final KnockException EXCEPTION = new BackgroundImageNotFoundException();
+    public static final KnockException EXCEPTION = new AppVersionNotFoundException();
 
-    private BackgroundImageNotFoundException() {
-        super(ErrorCode.BACKGROUND_NOT_FOUND);
+    private AppVersionNotFoundException() {
+        super(ErrorCode.APP_VERSION_NOT_FOUND);
     }
 
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/exception/AppVersionNotFoundException.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/exception/AppVersionNotFoundException.java
@@ -1,0 +1,14 @@
+package io.github.depromeet.knockknockbackend.domain.asset.exception;
+
+import io.github.depromeet.knockknockbackend.global.error.exception.ErrorCode;
+import io.github.depromeet.knockknockbackend.global.error.exception.KnockException;
+
+public class BackgroundImageNotFoundException extends KnockException {
+
+    public static final KnockException EXCEPTION = new BackgroundImageNotFoundException();
+
+    private BackgroundImageNotFoundException() {
+        super(ErrorCode.BACKGROUND_NOT_FOUND);
+    }
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/presentation/AssetController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/presentation/AssetController.java
@@ -1,20 +1,25 @@
 package io.github.depromeet.knockknockbackend.domain.asset.presentation;
 
+import io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response.AppVersionResponse;
 import io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response.ProfileImageDto;
 import io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response.ProfileImagesResponse;
 import io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response.ReactionsResponse;
 import io.github.depromeet.knockknockbackend.domain.asset.service.AssetService;
 import io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response.BackgroundsResponse;
 import io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response.ThumbnailsResponse;
+import io.github.depromeet.knockknockbackend.global.annotation.DisableSecurity;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
-@RestController("/asset")
+@RequestMapping("/asset")
+@RestController
 @Tag(name = "이미지 관련 컨트롤러", description = "")
 @SecurityRequirement(name = "access-token")
 public class AssetController {
@@ -50,4 +55,11 @@ public class AssetController {
         return assetService.getAllReactionImages();
     }
 
+    @Operation(summary = "앱버젼 api ")
+    @DisableSecurity
+    @Tag(name = "앱버젼 체크")
+    @GetMapping("/version")
+    public AppVersionResponse getAppVersion(){
+        return assetService.getAppVersion();
+    }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/presentation/dto/response/AppVersionResponse.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/presentation/dto/response/AppVersionResponse.java
@@ -1,0 +1,2 @@
+package io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response;public class AppVersionResponse {
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/presentation/dto/response/AppVersionResponse.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/presentation/dto/response/AppVersionResponse.java
@@ -1,2 +1,12 @@
-package io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response;public class AppVersionResponse {
+package io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class AppVersionResponse {
+
+    private final String version;
+    public AppVersionResponse(String version) {
+        this.version = version;
+    }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/service/AssetService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/asset/service/AssetService.java
@@ -1,11 +1,15 @@
 package io.github.depromeet.knockknockbackend.domain.asset.service;
 
+import io.github.depromeet.knockknockbackend.domain.asset.domain.AppVersion;
 import io.github.depromeet.knockknockbackend.domain.asset.domain.BackgroundImage;
 import io.github.depromeet.knockknockbackend.domain.asset.domain.ProfileImage;
 import io.github.depromeet.knockknockbackend.domain.asset.domain.Thumbnail;
+import io.github.depromeet.knockknockbackend.domain.asset.domain.repository.AppVersionRepository;
 import io.github.depromeet.knockknockbackend.domain.asset.domain.repository.ProfileImageRepository;
 import io.github.depromeet.knockknockbackend.domain.asset.domain.repository.ReactionRepository;
+import io.github.depromeet.knockknockbackend.domain.asset.exception.AppVersionNotFoundException;
 import io.github.depromeet.knockknockbackend.domain.asset.exception.ProfileImageNotFoundException;
+import io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response.AppVersionResponse;
 import io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response.ProfileImageDto;
 import io.github.depromeet.knockknockbackend.domain.asset.presentation.dto.response.ProfileImagesResponse;
 import io.github.depromeet.knockknockbackend.domain.asset.domain.repository.BackGroundImageRepository;
@@ -34,6 +38,8 @@ public class AssetService implements AssetUtils {
     private final ProfileImageRepository profileImageRepository;
 
     private final ReactionRepository reactionRepository;
+
+    private final AppVersionRepository appVersionRepository;
 
     public String getRandomBackgroundImageUrl() {
         BackgroundImage randomBackground = backGroundImageRepository.findRandomBackgroundImage()
@@ -83,5 +89,11 @@ public class AssetService implements AssetUtils {
             .map(ReactionImageDto::new)
             .collect(Collectors.toList());
         return new ReactionsResponse(reactionImageDtos);
+    }
+
+    public AppVersionResponse getAppVersion(){
+        AppVersion appVersion = appVersionRepository.findAll().stream().findFirst()
+            .orElseThrow(() -> AppVersionNotFoundException.EXCEPTION);
+        return new AppVersionResponse(appVersion.getVersion());
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/annotation/DisableSecurity.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/annotation/DisableSecurity.java
@@ -1,0 +1,12 @@
+package io.github.depromeet.knockknockbackend.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DisableSecurity {
+
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/config/SecurityConfig.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                 .antMatchers(SwaggerPatterns).permitAll()
                 .antMatchers("/actuator/**").permitAll()
                 .antMatchers("/credentials/**").permitAll()
+                .antMatchers("/asset/version").permitAll()
                 .anyRequest().authenticated();
         http
             .apply(new FilterConfig(jwtTokenProvider, objectMapper));

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/config/SwaggerConfig.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/config/SwaggerConfig.java
@@ -2,7 +2,9 @@ package io.github.depromeet.knockknockbackend.global.config;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.depromeet.knockknockbackend.global.annotation.DisableSecurity;
 import io.swagger.v3.core.jackson.ModelResolver;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.Components;
@@ -10,9 +12,11 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityScheme.In;
 import io.swagger.v3.oas.models.security.SecurityScheme.Type;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 
@@ -56,8 +60,23 @@ public class SwaggerConfig {
         return new ModelResolver(objectMapper);
     }
 
-    //    static {
-    //        SpringDocUtils.getConfig().addAnnotationsToIgnore(MemberId.class);
-    //    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            DisableSecurity methodAnnotation = handlerMethod.getMethodAnnotation(
+                DisableSecurity.class);
+            // DisableSecurity 어노테이션있을시 스웨거 시큐리티 설정 삭제
+            if(methodAnnotation != null){
+                operation.setSecurity(Collections.emptyList());
+            }
+            //태그 중복 설정시 제일 구체적인 값만 태그로 설정
+            List<String> tags = operation.getTags();
+            if(tags != null && !tags.isEmpty() ){
+                operation.setTags(Collections.singletonList(tags.get(0)));
+            }
+            return operation;
+        };
+    }
 
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/error/exception/ErrorCode.java
@@ -53,8 +53,8 @@ public enum ErrorCode {
 
     PROFILE_IMAGE_NOT_FOUND(404,"ASSET-404-1", "PROFILE Not Found"),
     BACKGROUND_NOT_FOUND(404,"ASSET-404-2", "BACKGROUND Not Found"),
-    THUMBNAIL_NOT_FOUND(404,"ASSET-404-3", "THUMBNAIL Not Found");
-
+    THUMBNAIL_NOT_FOUND(404,"ASSET-404-3", "THUMBNAIL Not Found"),
+    APP_VERSION_NOT_FOUND(404,"ASSET-404-4", "APP_VERSION Not Found");
 
     private int status;
     private String code;

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -69,3 +69,8 @@ VALUES
     (11,'https://user-images.githubusercontent.com/13329304/207664192-f91c9508-ea3c-474e-8038-34c2da08eb77.png','party',1100),
     (12,'https://user-images.githubusercontent.com/13329304/207664212-5dfdba3b-4de9-40c4-a564-f14f6474955e.png','eye',1200)
     ON DUPLICATE KEY UPDATE image_url = VALUES (image_url) ,title = VALUES (title) ,list_order = VALUES (list_order);
+
+INSERT INTO tbl_app_version(id, version)
+VALUES
+    (1,'0.0.1')
+    ON DUPLICATE KEY UPDATE version = VALUES (version);


### PR DESCRIPTION
- 앱 버젼 체크 api 추가
 - 스웨거 커스터마이징 했습니다
 - 컨트롤러에 전체적으로 시큐리티 설정하면 메소드에서 시큐리티 빼고싶어도 못빼는 경우가 있습니다.


![자물쇠 제거](https://user-images.githubusercontent.com/13329304/208241063-e1118be2-8077-4ab4-8a76-fc600b956225.jpg)
위처럼 자물쇠 없애는 커스터마이징을 진행했습니다

DisableSecurity 어노테이션 을 메소드에 달시에
리플렉션으로 메소드 가져와서 security 에 설정되어있던거 emptyList 로 반환합니다.

물론 스프링 시큐리티에서 permit 설정을 해줘야되긴합니다.
스프링 시큐리티에서 설정도 동적으로 리플랙션으로 DisableSecurity 어노테이션 달린 놈들 빼와서 설정해줄수 있을것같은데
일단 냅뒀습니다

자물쇠를 컨트롤러안에 메소드에서 뺄수있습니다!
 
 - 태그 달았을 때 컨트롤러 , 메소드에 둘다 달리면
![앱 버젼체크 태그중복](https://user-images.githubusercontent.com/13329304/208240892-e8610b3d-89f2-4a89-9f17-53416cf68dff.jpg)

위처럼 중복해서 달립니다.
없애기 위해
커스터마이저에 제일 구체적인 태그만 적용하도록 커스터마이징 했습니다.
related issue
 - https://github.com/springdoc/springdoc-openapi/issues/271

close #78 
