### PR TITLE
🔀 :: (#197) oauth oidc 방식으로 회원가입

### DIFF
--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/CredentialController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/CredentialController.java
@@ -2,9 +2,11 @@ package io.github.depromeet.knockknockbackend.domain.credential.presentation;
 
 
 import io.github.depromeet.knockknockbackend.domain.credential.presentation.dto.request.OauthCodeRequest;
+import io.github.depromeet.knockknockbackend.domain.credential.presentation.dto.request.RegisterRequest;
 import io.github.depromeet.knockknockbackend.domain.credential.presentation.dto.request.TokenRefreshRequest;
 import io.github.depromeet.knockknockbackend.domain.credential.presentation.dto.response.AfterOauthResponse;
 import io.github.depromeet.knockknockbackend.domain.credential.presentation.dto.response.AuthTokensResponse;
+import io.github.depromeet.knockknockbackend.domain.credential.presentation.dto.response.AvailableRegisterResponse;
 import io.github.depromeet.knockknockbackend.domain.credential.presentation.dto.response.OauthLoginLinkResponse;
 import io.github.depromeet.knockknockbackend.domain.credential.service.CredentialService;
 import io.github.depromeet.knockknockbackend.domain.credential.service.OauthProvider;
@@ -15,11 +17,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,7 +34,10 @@ public class CredentialController {
 
     private final CredentialService credentialService;
 
-    @Operation(summary = "kakao oauth 링크발급", description = "kakao 링크를 받아볼수 있습니다." ,deprecated = true)
+    @Operation(
+            summary = "kakao oauth 링크발급",
+            description = "kakao 링크를 받아볼수 있습니다.",
+            deprecated = true)
     @GetMapping("/oauth/link/kakao")
     public OauthLoginLinkResponse getKakaoOauthLink() {
         return new OauthLoginLinkResponse(credentialService.getOauthLink(OauthProvider.KAKAO));
@@ -59,14 +66,17 @@ public class CredentialController {
                                         schema =
                                                 @Schema(implementation = AfterOauthResponse.class)))
             })
-    @Operation(summary = "kakao oauth 요청", description = "code를 서버로 요청보냅니다." ,deprecated = true)
+    @Operation(summary = "kakao oauth 요청", description = "code를 서버로 요청보냅니다.", deprecated = true)
     @GetMapping("/oauth/kakao")
     public AfterOauthResponse kakaoAuth(OauthCodeRequest oauthCodeRequest) {
         // TODO : 사용자가 로그인 취소시에 code 안넘어옴 별도 처리 필요.
         return credentialService.oauthCodeToUser(OauthProvider.KAKAO, oauthCodeRequest.getCode());
     }
 
-    @Operation(summary = "google oauth 링크발급", description = "oauth 링크를 받아볼수 있습니다." , deprecated = true)
+    @Operation(
+            summary = "google oauth 링크발급",
+            description = "oauth 링크를 받아볼수 있습니다.",
+            deprecated = true)
     @GetMapping("/oauth/link/google")
     public OauthLoginLinkResponse getGoogleOauthLink() {
         return new OauthLoginLinkResponse(credentialService.getOauthLink(OauthProvider.GOOGLE));
@@ -95,18 +105,43 @@ public class CredentialController {
                                         schema =
                                                 @Schema(implementation = AfterOauthResponse.class)))
             })
-    @Operation(summary = "google oauth 요청", description = "code를 서버로 요청보냅니다." ,deprecated = true)
+    @Operation(summary = "google oauth 요청", description = "code를 서버로 요청보냅니다.", deprecated = true)
     @GetMapping("/oauth/google")
     public AfterOauthResponse googleAuth(OauthCodeRequest oauthCodeRequest) {
         return credentialService.oauthCodeToUser(OauthProvider.GOOGLE, oauthCodeRequest.getCode());
+    }
+
+    @Operation(summary = "oauth 토큰을 검증 합니다", description = "토큰을 리프레쉬 합니다.")
+    @GetMapping("/oauth/valid/register")
+    public AvailableRegisterResponse valid(
+            @RequestParam("id_token") String token,
+            @RequestParam("provider") OauthProvider oauthProvider) {
+        return credentialService.getUserAvailableRegister(token, oauthProvider);
+    }
+
+    @Operation(summary = "등록 요청", description = "토큰을 리프레쉬 합니다.")
+    @PostMapping("/register")
+    public AuthTokensResponse registerUser(
+            @RequestParam("id_token") String token,
+            @RequestParam("provider") OauthProvider oauthProvider,
+            @RequestBody @Valid RegisterRequest registerRequest) {
+
+        return credentialService.registerUserByOCIDToken(token, registerRequest, oauthProvider);
+    }
+
+    @Operation(summary = "로그인 요청", description = "이미 가입된 사용자면 로그인 요청을 합니다")
+    @PostMapping("/login")
+    public AuthTokensResponse loginUser(
+            @RequestParam("id_token") String token,
+            @RequestParam("provider") OauthProvider oauthProvider) {
+        return credentialService.loginUserByOCIDToken(token, oauthProvider);
     }
 
     @Operation(summary = "토큰 리프레쉬", description = "토큰을 리프레쉬 합니다.")
     @PostMapping("/refresh")
     public AuthTokensResponse refreshingToken(
             @RequestBody TokenRefreshRequest tokenRefreshRequest) {
-        AuthTokensResponse authTokensResponse =
-                credentialService.tokenRefresh(tokenRefreshRequest.getRefreshToken());
-        return authTokensResponse;
+
+        return credentialService.tokenRefresh(tokenRefreshRequest.getRefreshToken());
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/CredentialController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/CredentialController.java
@@ -30,7 +30,7 @@ public class CredentialController {
 
     private final CredentialService credentialService;
 
-    @Operation(summary = "kakao oauth 링크발급", description = "kakao 링크를 받아볼수 있습니다.")
+    @Operation(summary = "kakao oauth 링크발급", description = "kakao 링크를 받아볼수 있습니다." ,deprecated = true)
     @GetMapping("/oauth/link/kakao")
     public OauthLoginLinkResponse getKakaoOauthLink() {
         return new OauthLoginLinkResponse(credentialService.getOauthLink(OauthProvider.KAKAO));
@@ -59,14 +59,14 @@ public class CredentialController {
                                         schema =
                                                 @Schema(implementation = AfterOauthResponse.class)))
             })
-    @Operation(summary = "kakao oauth 요청", description = "code를 서버로 요청보냅니다.")
+    @Operation(summary = "kakao oauth 요청", description = "code를 서버로 요청보냅니다." ,deprecated = true)
     @GetMapping("/oauth/kakao")
     public AfterOauthResponse kakaoAuth(OauthCodeRequest oauthCodeRequest) {
         // TODO : 사용자가 로그인 취소시에 code 안넘어옴 별도 처리 필요.
         return credentialService.oauthCodeToUser(OauthProvider.KAKAO, oauthCodeRequest.getCode());
     }
 
-    @Operation(summary = "google oauth 링크발급", description = "oauth 링크를 받아볼수 있습니다.")
+    @Operation(summary = "google oauth 링크발급", description = "oauth 링크를 받아볼수 있습니다." , deprecated = true)
     @GetMapping("/oauth/link/google")
     public OauthLoginLinkResponse getGoogleOauthLink() {
         return new OauthLoginLinkResponse(credentialService.getOauthLink(OauthProvider.GOOGLE));
@@ -95,7 +95,7 @@ public class CredentialController {
                                         schema =
                                                 @Schema(implementation = AfterOauthResponse.class)))
             })
-    @Operation(summary = "google oauth 요청", description = "code를 서버로 요청보냅니다.")
+    @Operation(summary = "google oauth 요청", description = "code를 서버로 요청보냅니다." ,deprecated = true)
     @GetMapping("/oauth/google")
     public AfterOauthResponse googleAuth(OauthCodeRequest oauthCodeRequest) {
         return credentialService.oauthCodeToUser(OauthProvider.GOOGLE, oauthCodeRequest.getCode());

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/dto/request/RegisterRequest.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/dto/request/RegisterRequest.java
@@ -1,4 +1,4 @@
-package io.github.depromeet.knockknockbackend.domain.user.presentation.dto.request;
+package io.github.depromeet.knockknockbackend.domain.credential.presentation.dto.request;
 
 
 import javax.validation.constraints.NotEmpty;
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class ChangeProfileRequest {
+public class RegisterRequest {
 
     @Size(max = 10)
     @NotEmpty

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/dto/request/RegisterRequest.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/dto/request/RegisterRequest.java
@@ -1,0 +1,18 @@
+package io.github.depromeet.knockknockbackend.domain.user.presentation.dto.request;
+
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChangeProfileRequest {
+
+    @Size(max = 10)
+    @NotEmpty
+    private String nickname;
+
+    @NotEmpty private String profilePath;
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/dto/response/AvailableRegisterResponse.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/dto/response/AvailableRegisterResponse.java
@@ -1,0 +1,20 @@
+package io.github.depromeet.knockknockbackend.domain.credential.presentation.dto.response;
+
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AfterOauthResponse {
+
+    @Schema(description = "어세스 토큰")
+    private String accessToken;
+
+    @Schema(description = "리프레쉬 토큰")
+    private String refreshToken;
+
+    @Schema(description = "회원가입을 했던 유저인지에 대한 여부 , oauth 요청을 통해 처음 회원가입한경우 false임")
+    private Boolean isRegistered;
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/dto/response/AvailableRegisterResponse.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/dto/response/AvailableRegisterResponse.java
@@ -2,18 +2,12 @@ package io.github.depromeet.knockknockbackend.domain.credential.presentation.dto
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@Builder
-public class AfterOauthResponse {
-
-    @Schema(description = "어세스 토큰")
-    private String accessToken;
-
-    @Schema(description = "리프레쉬 토큰")
-    private String refreshToken;
+@AllArgsConstructor
+public class AvailableRegisterResponse {
 
     @Schema(description = "회원가입을 했던 유저인지에 대한 여부 , oauth 요청을 통해 처음 회원가입한경우 false임")
     private Boolean isRegistered;

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/CredentialService.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/CredentialService.java
@@ -130,7 +130,7 @@ public class CredentialService {
             String token, OauthProvider oauthProvider) {
         OauthStrategy oauthStrategy = oauthFactory.getOauthstrategy(oauthProvider);
         OIDCDecodePayload oidcDecodePayload = oauthStrategy.getOIDCDecodePayload(token);
-        Boolean isRegistered = checkUserCanRegister(oidcDecodePayload, oauthProvider);
+        Boolean isRegistered = !checkUserCanRegister(oidcDecodePayload, oauthProvider);
 
         return new AvailableRegisterResponse(isRegistered);
     }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/GoogleOauthStrategy.java
@@ -6,6 +6,7 @@ import io.github.depromeet.knockknockbackend.global.property.OauthProperties;
 import io.github.depromeet.knockknockbackend.global.utils.api.client.GoogleAuthClient;
 import io.github.depromeet.knockknockbackend.global.utils.api.client.GoogleInfoClient;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.GoogleInformationResponse;
+import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OIDCPublicKeysResponse;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import lombok.AllArgsConstructor;
@@ -22,6 +23,11 @@ public class GoogleOauthStrategy implements OauthStrategy {
     private final OauthProperties oauthProperties;
     private final GoogleAuthClient googleAuthClient;
     private final GoogleInfoClient googleInfoClient;
+
+    private final OauthOIDCProvider oauthOIDCProvider;
+
+
+    private static final String ISSUER = "https://accounts.google.com";
 
     // oauthLink 발급
     public String getOauthLink() {
@@ -47,6 +53,11 @@ public class GoogleOauthStrategy implements OauthStrategy {
                 .getAccessToken();
     }
 
+    @Override
+    public OIDCDecodePayload getOIDCDecodePayload(String token) {
+        OIDCPublicKeysResponse oidcPublicKeysResponse = googleAuthClient.getGoogleOIDCOpenKeys();
+        return oauthOIDCProvider.getPayloadFromIdToken(token,ISSUER,oauthProperties.getGoogleClientId(),oidcPublicKeysResponse);
+    }
     // 발급된 어세스 토큰으로 유저정보 조회
     public OauthCommonUserInfoDto getUserInfo(String oauthAccessToken) {
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/GoogleOauthStrategy.java
@@ -13,7 +13,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @AllArgsConstructor
-@Component("google")
+@Component("GOOGLE")
 public class GoogleOauthStrategy implements OauthStrategy {
 
     private static final String QUERY_STRING =

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/GoogleOauthStrategy.java
@@ -26,7 +26,6 @@ public class GoogleOauthStrategy implements OauthStrategy {
 
     private final OauthOIDCProvider oauthOIDCProvider;
 
-
     private static final String ISSUER = "https://accounts.google.com";
 
     // oauthLink 발급
@@ -56,7 +55,8 @@ public class GoogleOauthStrategy implements OauthStrategy {
     @Override
     public OIDCDecodePayload getOIDCDecodePayload(String token) {
         OIDCPublicKeysResponse oidcPublicKeysResponse = googleAuthClient.getGoogleOIDCOpenKeys();
-        return oauthOIDCProvider.getPayloadFromIdToken(token,ISSUER,oauthProperties.getGoogleClientId(),oidcPublicKeysResponse);
+        return oauthOIDCProvider.getPayloadFromIdToken(
+                token, ISSUER, oauthProperties.getGoogleClientId(), oidcPublicKeysResponse);
     }
     // 발급된 어세스 토큰으로 유저정보 조회
     public OauthCommonUserInfoDto getUserInfo(String oauthAccessToken) {

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/KakaoOauthStrategy.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/KakaoOauthStrategy.java
@@ -12,7 +12,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @AllArgsConstructor
-@Component("kakao")
+@Component("KAKAO")
 public class KakaoOauthStrategy implements OauthStrategy {
 
     private static final String QUERY_STRING =

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/KakaoOauthStrategy.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/KakaoOauthStrategy.java
@@ -7,6 +7,7 @@ import io.github.depromeet.knockknockbackend.global.utils.api.client.KakaoInfoCl
 import io.github.depromeet.knockknockbackend.global.utils.api.client.KakaoOauthClient;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.KakaoInformationResponse;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.KakaoInformationResponse.KakaoAccount;
+import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OIDCPublicKeysResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +21,9 @@ public class KakaoOauthStrategy implements OauthStrategy {
     private final OauthProperties oauthProperties;
     private final KakaoOauthClient kakaoOauthClient;
     private final KakaoInfoClient kakaoInfoClient;
+    private final OauthOIDCProvider oauthOIDCProvider;
+
+    private static final String ISSUER = "https://kauth.kakao.com";
 
     // oauthLink 발급
     public String getOauthLink() {
@@ -44,7 +48,6 @@ public class KakaoOauthStrategy implements OauthStrategy {
 
     // 발급된 어세스 토큰으로 유저정보 조회
     public OauthCommonUserInfoDto getUserInfo(String oauthAccessToken) {
-
         KakaoInformationResponse response =
                 kakaoInfoClient.kakaoUserInfo(PREFIX + oauthAccessToken);
         KakaoAccount kakaoAccount = response.getKakaoAccount();
@@ -63,4 +66,10 @@ public class KakaoOauthStrategy implements OauthStrategy {
 
         return oauthCommonUserInfoDtoBuilder.build();
     }
+    @Override
+    public OIDCDecodePayload getOIDCDecodePayload(String token) {
+        OIDCPublicKeysResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
+        return oauthOIDCProvider.getPayloadFromIdToken(token,ISSUER,oauthProperties.getKakaoClientId(),oidcPublicKeysResponse);
+    }
+
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/KakaoOauthStrategy.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/KakaoOauthStrategy.java
@@ -66,10 +66,11 @@ public class KakaoOauthStrategy implements OauthStrategy {
 
         return oauthCommonUserInfoDtoBuilder.build();
     }
+
     @Override
     public OIDCDecodePayload getOIDCDecodePayload(String token) {
         OIDCPublicKeysResponse oidcPublicKeysResponse = kakaoOauthClient.getKakaoOIDCOpenKeys();
-        return oauthOIDCProvider.getPayloadFromIdToken(token,ISSUER,oauthProperties.getKakaoClientId(),oidcPublicKeysResponse);
+        return oauthOIDCProvider.getPayloadFromIdToken(
+                token, ISSUER, oauthProperties.getKakaoClientId(), oidcPublicKeysResponse);
     }
-
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OIDCDecodePayload.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OIDCDecodePayload.java
@@ -1,0 +1,15 @@
+package io.github.depromeet.knockknockbackend.domain.credential.service;
+
+import lombok.Getter;
+
+@Getter
+public class OIDCDecodePayload {
+    /** issuer ex https://kauth.kakao.com */
+    private String iss;
+    /** client id */
+    private String aud;
+    /** oauth provider account unique id */
+    private String sub;
+
+    private String email;
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OIDCDecodePayload.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OIDCDecodePayload.java
@@ -1,5 +1,6 @@
 package io.github.depromeet.knockknockbackend.domain.credential.service;
 
+
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OIDCDecodePayload.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OIDCDecodePayload.java
@@ -1,9 +1,11 @@
 package io.github.depromeet.knockknockbackend.domain.credential.service;
 
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class OIDCDecodePayload {
     /** issuer ex https://kauth.kakao.com */
     private String iss;

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthOIDCProvider.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthOIDCProvider.java
@@ -1,5 +1,6 @@
 package io.github.depromeet.knockknockbackend.domain.credential.service;
 
+
 import io.github.depromeet.knockknockbackend.global.security.JwtOIDCProvider;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OIDCPublicKeyDto;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OIDCPublicKeysResponse;
@@ -12,21 +13,22 @@ public class OauthOIDCProvider {
 
     private final JwtOIDCProvider jwtOIDCProvider;
 
-    private String getKidFromUnsignedIdToken(String token ,String iss ,String aud){
-        return jwtOIDCProvider.getKidFromUnsignedTokenHeader(token,iss,aud);
+    private String getKidFromUnsignedIdToken(String token, String iss, String aud) {
+        return jwtOIDCProvider.getKidFromUnsignedTokenHeader(token, iss, aud);
     }
 
-    public OIDCDecodePayload getPayloadFromIdToken(String token ,String iss ,String aud,
-        OIDCPublicKeysResponse oidcPublicKeysResponse){
-        String kid = getKidFromUnsignedIdToken(token,iss,aud);
+    public OIDCDecodePayload getPayloadFromIdToken(
+            String token, String iss, String aud, OIDCPublicKeysResponse oidcPublicKeysResponse) {
+        String kid = getKidFromUnsignedIdToken(token, iss, aud);
 
-        OIDCPublicKeyDto oidcPublicKeyDto = oidcPublicKeysResponse.getKeys().stream()
-            .filter(o -> o.getKid().equals(kid))
-            .findFirst()
-            .orElseThrow();
+        OIDCPublicKeyDto oidcPublicKeyDto =
+                oidcPublicKeysResponse.getKeys().stream()
+                        .filter(o -> o.getKid().equals(kid))
+                        .findFirst()
+                        .orElseThrow();
 
-        return (OIDCDecodePayload)jwtOIDCProvider.getOIDCTokenBody(token, oidcPublicKeyDto.getN(),
-            oidcPublicKeyDto.getE());
-
+        return (OIDCDecodePayload)
+                jwtOIDCProvider.getOIDCTokenBody(
+                        token, oidcPublicKeyDto.getN(), oidcPublicKeyDto.getE());
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthOIDCProvider.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthOIDCProvider.java
@@ -1,0 +1,32 @@
+package io.github.depromeet.knockknockbackend.domain.credential.service;
+
+import io.github.depromeet.knockknockbackend.global.security.JwtOIDCProvider;
+import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OIDCPublicKeyDto;
+import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OIDCPublicKeysResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OauthOIDCProvider {
+
+    private final JwtOIDCProvider jwtOIDCProvider;
+
+    private String getKidFromUnsignedIdToken(String token ,String iss ,String aud){
+        return jwtOIDCProvider.getKidFromUnsignedTokenHeader(token,iss,aud);
+    }
+
+    public OIDCDecodePayload getPayloadFromIdToken(String token ,String iss ,String aud,
+        OIDCPublicKeysResponse oidcPublicKeysResponse){
+        String kid = getKidFromUnsignedIdToken(token,iss,aud);
+
+        OIDCPublicKeyDto oidcPublicKeyDto = oidcPublicKeysResponse.getKeys().stream()
+            .filter(o -> o.getKid().equals(kid))
+            .findFirst()
+            .orElseThrow();
+
+        return (OIDCDecodePayload)jwtOIDCProvider.getOIDCTokenBody(token, oidcPublicKeyDto.getN(),
+            oidcPublicKeyDto.getE());
+
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthProvider.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthProvider.java
@@ -1,7 +1,6 @@
 package io.github.depromeet.knockknockbackend.domain.credential.service;
 
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,7 +11,6 @@ public enum OauthProvider {
     KAKAO("KAKAO"),
     GOOGLE("GOOGLE");
     private String oauthProviderName;
-
 
     @JsonValue
     public String getValue() {

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthProvider.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthProvider.java
@@ -9,19 +9,10 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum OauthProvider {
-    KAKAO("kakao"),
-    GOOGLE("google");
+    KAKAO("KAKAO"),
+    GOOGLE("GOOGLE");
     private String oauthProviderName;
 
-    @JsonCreator
-    public static OauthProvider from(String value) {
-        for (OauthProvider provider : OauthProvider.values()) {
-            if (provider.getValue().equals(value)) {
-                return provider;
-            }
-        }
-        return null;
-    }
 
     @JsonValue
     public String getValue() {

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthStrategy.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthStrategy.java
@@ -7,4 +7,6 @@ public interface OauthStrategy {
     String getOauthLink();
 
     String getAccessToken(String code);
+
+    OIDCDecodePayload getOIDCDecodePayload(String token);
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/User.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/User.java
@@ -35,12 +35,19 @@ public class User {
     private String profilePath;
 
     @Builder
-    public User(Long id, String nickname, String oauthProvider, String oauthId, String email) {
+    public User(
+            Long id,
+            String nickname,
+            String oauthProvider,
+            String oauthId,
+            String email,
+            String profilePath) {
         this.id = id;
         this.nickname = nickname;
         this.oauthProvider = oauthProvider;
         this.oauthId = oauthId;
         this.email = email;
+        this.profilePath = profilePath;
     }
 
     public UserInfoVO getUserInfo() {

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/config/RedisCacheConfig.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/config/RedisCacheConfig.java
@@ -6,6 +6,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -18,6 +19,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisCacheConfig {
 
     @Bean
+    @Primary
     public CacheManager redisCacheManager(RedisConnectionFactory cf) {
         RedisCacheConfiguration redisCacheConfiguration =
                 RedisCacheConfiguration.defaultCacheConfig()
@@ -32,5 +34,22 @@ public class RedisCacheConfig {
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
                 .cacheDefaults(redisCacheConfiguration)
                 .build();
+    }
+
+    @Bean
+    public CacheManager oidcCacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration redisCacheConfiguration =
+            RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                    RedisSerializationContext.SerializationPair.fromSerializer(
+                        new StringRedisSerializer()))
+                .serializeValuesWith(
+                    RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofDays(7L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
+            .cacheDefaults(redisCacheConfiguration)
+            .build();
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/config/RedisCacheConfig.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/config/RedisCacheConfig.java
@@ -39,17 +39,17 @@ public class RedisCacheConfig {
     @Bean
     public CacheManager oidcCacheManager(RedisConnectionFactory cf) {
         RedisCacheConfiguration redisCacheConfiguration =
-            RedisCacheConfiguration.defaultCacheConfig()
-                .serializeKeysWith(
-                    RedisSerializationContext.SerializationPair.fromSerializer(
-                        new StringRedisSerializer()))
-                .serializeValuesWith(
-                    RedisSerializationContext.SerializationPair.fromSerializer(
-                        new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofDays(7L));
+                RedisCacheConfiguration.defaultCacheConfig()
+                        .serializeKeysWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new StringRedisSerializer()))
+                        .serializeValuesWith(
+                                RedisSerializationContext.SerializationPair.fromSerializer(
+                                        new GenericJackson2JsonRedisSerializer()))
+                        .entryTtl(Duration.ofDays(7L));
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
-            .cacheDefaults(redisCacheConfiguration)
-            .build();
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/security/JwtOIDCProvider.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/security/JwtOIDCProvider.java
@@ -32,8 +32,7 @@ public class JwtOIDCProvider {
     private final String KID = "kid";
 
     public String getKidFromUnsignedTokenHeader(String token, String iss, String aud) {
-        return (String)
-                getUnsignedTokenClaims(token, iss, aud).getHeader().get(KID);
+        return (String) getUnsignedTokenClaims(token, iss, aud).getHeader().get(KID);
     }
 
     private Jwt<Header, Claims> getUnsignedTokenClaims(String token, String iss, String aud) {
@@ -53,8 +52,7 @@ public class JwtOIDCProvider {
 
     private String getUnsignedToken(String token) {
         String[] splitToken = token.split("\\.");
-        if(splitToken.length !=3)
-            throw InvalidTokenException.EXCEPTION;
+        if (splitToken.length != 3) throw InvalidTokenException.EXCEPTION;
         return splitToken[0] + "." + splitToken[1] + ".";
     }
 
@@ -74,8 +72,11 @@ public class JwtOIDCProvider {
 
     public OIDCDecodePayload getOIDCTokenBody(String token, String modulus, String exponent) {
         Claims body = getOIDCTokenJws(token, modulus, exponent).getBody();
-        return new OIDCDecodePayload(body.getIssuer(), body.getAudience(), body.getSubject(), body.get("email",String.class));
-
+        return new OIDCDecodePayload(
+                body.getIssuer(),
+                body.getAudience(),
+                body.getSubject(),
+                body.get("email", String.class));
     }
 
     private Key getRSAPublicKey(String modulus, String exponent)

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/security/JwtOIDCProvider.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/security/JwtOIDCProvider.java
@@ -1,5 +1,6 @@
 package io.github.depromeet.knockknockbackend.global.security;
 
+
 import io.github.depromeet.knockknockbackend.global.exception.ExpiredTokenException;
 import io.github.depromeet.knockknockbackend.global.exception.InvalidTokenException;
 import io.github.depromeet.knockknockbackend.global.property.JwtProperties;
@@ -16,6 +17,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
+import java.util.Date;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -27,25 +29,19 @@ public class JwtOIDCProvider {
 
     private final String KID = "kid";
 
-    public String getKidFromTokenHeader(String token) {
-        return (String) getUnsignedTokenClaims(getUnsignedToken(token)).getHeader().get(KID);
+    public String getKidFromUnsignedTokenHeader(String token, String iss, String aud) {
+        return (String)
+                getUnsignedTokenClaims(getUnsignedToken(token), iss, aud).getHeader().get(KID);
     }
 
-    private Jwt<Header, Claims> getUnsignedTokenClaims(String unsignedToken) {
-        return Jwts.parserBuilder().build().parseClaimsJwt(unsignedToken);
-    }
-
-    private String getUnsignedToken(String token) {
-        String[] splitToken = token.split("\\.");
-        return splitToken[0] + "." + splitToken[1] + ".";
-    }
-
-    public Jws<Claims> getOIDCTokenJws(String token, String modulus , String exponent) {
+    private Jwt<Header, Claims> getUnsignedTokenClaims(String token, String iss, String aud) {
         try {
             return Jwts.parserBuilder()
-                .setSigningKey(getRSAPublicKey(modulus,exponent))
-                .build()
-                .parseClaimsJws(token);
+                    .requireAudience(aud)
+                    .requireIssuer(iss)
+                    .requireExpiration(new Date())
+                    .build()
+                    .parseClaimsJwt(getUnsignedToken(token));
         } catch (ExpiredJwtException e) {
             throw ExpiredTokenException.EXCEPTION;
         } catch (Exception e) {
@@ -53,8 +49,30 @@ public class JwtOIDCProvider {
         }
     }
 
-    private Key getRSAPublicKey(String modulus , String exponent)
-        throws NoSuchAlgorithmException, InvalidKeySpecException {
+    private String getUnsignedToken(String token) {
+        String[] splitToken = token.split("\\.");
+        return splitToken[0] + "." + splitToken[1] + ".";
+    }
+
+    public Jws<Claims> getOIDCTokenJws(String token, String modulus, String exponent) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(getRSAPublicKey(modulus, exponent))
+                    .build()
+                    .parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw ExpiredTokenException.EXCEPTION;
+        } catch (Exception e) {
+            throw InvalidTokenException.EXCEPTION;
+        }
+    }
+
+    public Claims getOIDCTokenBody(String token, String modulus, String exponent) {
+        return getOIDCTokenJws(token, modulus, exponent).getBody();
+    }
+
+    private Key getRSAPublicKey(String modulus, String exponent)
+            throws NoSuchAlgorithmException, InvalidKeySpecException {
         KeyFactory keyFactory = KeyFactory.getInstance("RSA");
         byte[] decodeN = Base64.getUrlDecoder().decode(modulus);
         byte[] decodeE = Base64.getUrlDecoder().decode(exponent);

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/security/JwtOIDCProvider.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/security/JwtOIDCProvider.java
@@ -1,0 +1,67 @@
+package io.github.depromeet.knockknockbackend.global.security;
+
+import io.github.depromeet.knockknockbackend.global.exception.ExpiredTokenException;
+import io.github.depromeet.knockknockbackend.global.exception.InvalidTokenException;
+import io.github.depromeet.knockknockbackend.global.property.JwtProperties;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.Jwts;
+import java.math.BigInteger;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class JwtOIDCProvider {
+
+    private final JwtProperties jwtProperties;
+
+    private final String KID = "kid";
+
+    public String getKidFromTokenHeader(String token) {
+        return (String) getUnsignedTokenClaims(getUnsignedToken(token)).getHeader().get(KID);
+    }
+
+    private Jwt<Header, Claims> getUnsignedTokenClaims(String unsignedToken) {
+        return Jwts.parserBuilder().build().parseClaimsJwt(unsignedToken);
+    }
+
+    private String getUnsignedToken(String token) {
+        String[] splitToken = token.split("\\.");
+        return splitToken[0] + "." + splitToken[1] + ".";
+    }
+
+    public Jws<Claims> getOIDCTokenJws(String token, String modulus , String exponent) {
+        try {
+            return Jwts.parserBuilder()
+                .setSigningKey(getRSAPublicKey(modulus,exponent))
+                .build()
+                .parseClaimsJws(token);
+        } catch (ExpiredJwtException e) {
+            throw ExpiredTokenException.EXCEPTION;
+        } catch (Exception e) {
+            throw InvalidTokenException.EXCEPTION;
+        }
+    }
+
+    private Key getRSAPublicKey(String modulus , String exponent)
+        throws NoSuchAlgorithmException, InvalidKeySpecException {
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        byte[] decodeN = Base64.getUrlDecoder().decode(modulus);
+        byte[] decodeE = Base64.getUrlDecoder().decode(exponent);
+        BigInteger n = new BigInteger(1, decodeN);
+        BigInteger e = new BigInteger(1, decodeE);
+
+        RSAPublicKeySpec keySpec = new RSAPublicKeySpec(n, e);
+        return keyFactory.generatePublic(keySpec);
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/GoogleAuthClient.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/GoogleAuthClient.java
@@ -3,6 +3,7 @@ package io.github.depromeet.knockknockbackend.global.utils.api.client;
 
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OIDCPublicKeysResponse;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OauthAccessTokenResponse;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,6 +22,7 @@ public interface GoogleAuthClient {
             @PathVariable("CODE") String code,
             @PathVariable("CLIENT_SECRET") String client_secret);
 
+    @Cacheable(cacheNames = "GoogleOICD", cacheManager = "oidcCacheManager")
     @GetMapping("/v3/certs")
     OIDCPublicKeysResponse getGoogleOIDCOpenKeys();
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/GoogleAuthClient.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/GoogleAuthClient.java
@@ -1,21 +1,26 @@
 package io.github.depromeet.knockknockbackend.global.utils.api.client;
 
 
+import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OIDCPublicKeysResponse;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OauthAccessTokenResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
-@FeignClient(name = "GoogleAuthClient", url = "https://www.googleapis.com/oauth2/v4")
+@FeignClient(name = "GoogleAuthClient", url = "https://www.googleapis.com/oauth2")
 public interface GoogleAuthClient {
 
     // EmptyDto 411 구글에서 content length 없다고함
     // https://github.com/OpenFeign/feign/issues/1251
     @PostMapping(
-            "/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}&client_secret={CLIENT_SECRET}")
+            "/v4/token?grant_type=authorization_code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&code={CODE}&client_secret={CLIENT_SECRET}")
     OauthAccessTokenResponse googleAuth(
             @PathVariable("CLIENT_ID") String clientId,
             @PathVariable("REDIRECT_URI") String redirectUri,
             @PathVariable("CODE") String code,
             @PathVariable("CLIENT_SECRET") String client_secret);
+
+    @GetMapping("/v3/certs")
+    OIDCPublicKeysResponse getGoogleOIDCOpenKeys();
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/KakaoOauthClient.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/KakaoOauthClient.java
@@ -3,6 +3,7 @@ package io.github.depromeet.knockknockbackend.global.utils.api.client;
 
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OIDCPublicKeysResponse;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OauthAccessTokenResponse;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,6 +20,7 @@ public interface KakaoOauthClient {
             @PathVariable("CODE") String code,
             @PathVariable("CLIENT_SECRET") String client_secret);
 
+    @Cacheable(cacheNames = "KakaoOICD", cacheManager = "oidcCacheManager")
     @GetMapping("/.well-known/jwks.json")
     OIDCPublicKeysResponse getKakaoOIDCOpenKeys();
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/KakaoOauthClient.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/KakaoOauthClient.java
@@ -1,8 +1,10 @@
 package io.github.depromeet.knockknockbackend.global.utils.api.client;
 
 
+import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OIDCPublicKeysResponse;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OauthAccessTokenResponse;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 
@@ -16,4 +18,7 @@ public interface KakaoOauthClient {
             @PathVariable("REDIRECT_URI") String redirectUri,
             @PathVariable("CODE") String code,
             @PathVariable("CLIENT_SECRET") String client_secret);
+
+    @GetMapping("/.well-known/jwks.json")
+    OIDCPublicKeysResponse getKakaoOIDCOpenKeys();
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/dto/response/OIDCPublicKeyDto.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/dto/response/OIDCPublicKeyDto.java
@@ -1,5 +1,6 @@
 package io.github.depromeet.knockknockbackend.global.utils.api.dto.response;
 
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/dto/response/OIDCPublicKeyDto.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/dto/response/OIDCPublicKeyDto.java
@@ -1,0 +1,14 @@
+package io.github.depromeet.knockknockbackend.global.utils.api.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OIDCPublicKeyDto {
+    private String kid;
+    private String alg;
+    private String use;
+    private String n;
+    private String e;
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/dto/response/OIDCPublicKeysResponse.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/dto/response/OIDCPublicKeysResponse.java
@@ -1,0 +1,10 @@
+package io.github.depromeet.knockknockbackend.global.utils.api.dto.response;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+@Getter
+@NoArgsConstructor
+public class OIDCPublicKeysResponse {
+  List<OIDCPublicKeyDto> keys;
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/dto/response/OIDCPublicKeysResponse.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/dto/response/OIDCPublicKeysResponse.java
@@ -1,10 +1,12 @@
 package io.github.depromeet.knockknockbackend.global.utils.api.dto.response;
 
+
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 @Getter
 @NoArgsConstructor
 public class OIDCPublicKeysResponse {
-  List<OIDCPublicKeyDto> keys;
+    List<OIDCPublicKeyDto> keys;
 }


### PR DESCRIPTION
 - close #197 
 - id_token 으로 인증합니다
 - 각 오어스 서버에서 퍼블릭 키를 받아옵니다
 - 받아온 퍼블릭키는 Feign Client 단에서 7일간 캐시처리 되어있습니다
 - 회원가입한 회원인지 확인
 - 회원가입
 - 로그인

세개로 구현했습니다
![무제](https://user-images.githubusercontent.com/13329304/208773361-b8dd6fc9-1de0-4585-a410-e685459e966a.jpg)
6번 빼고 구현되어있습니다.

id token 의 헤더에서 kid 뽑고
오어스에서 받아온 public keys 목록에서 kid 로 퍼블리키뽑고
n ,e 로 RSA 형식 만든뒤에
jwt를 public키로 인증 하는 방식입니다.

인증시도 전에도 iss, aud 확인합니다

백엔드 분들은 기존 오어스 어세스토큰 받아오는 방식대로 계속하시면됩니다.
그리고 로컬 환경변수에 리다이렉션 url /api/v1 붙이셔야합니다!
