### PR TITLE
🔀 :: (#188) 유저 탈퇴

### DIFF
--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/event/DeleteUserEvent.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/event/DeleteUserEvent.java
@@ -1,0 +1,12 @@
+package io.github.depromeet.knockknockbackend.domain.credential.event;
+
+
+import io.github.depromeet.knockknockbackend.global.event.DomainEvent;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DeleteUserEvent implements DomainEvent {
+    private final Long userId;
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/CredentialController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/presentation/CredentialController.java
@@ -16,9 +16,11 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -135,6 +137,13 @@ public class CredentialController {
             @RequestParam("id_token") String token,
             @RequestParam("provider") OauthProvider oauthProvider) {
         return credentialService.loginUserByOCIDToken(token, oauthProvider);
+    }
+
+    @SecurityRequirement(name = "access-token")
+    @Operation(summary = "회원 탈퇴를 합니다. oauth 연결도 unlink 합니다. ")
+    @DeleteMapping("/me")
+    public void deleteUser(@RequestParam("oauth_access_token") String token) {
+        credentialService.deleteUser(token);
     }
 
     @Operation(summary = "토큰 리프레쉬", description = "토큰을 리프레쉬 합니다.")

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/GoogleOauthStrategy.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/GoogleOauthStrategy.java
@@ -5,6 +5,7 @@ import io.github.depromeet.knockknockbackend.domain.credential.service.OauthComm
 import io.github.depromeet.knockknockbackend.global.property.OauthProperties;
 import io.github.depromeet.knockknockbackend.global.utils.api.client.GoogleAuthClient;
 import io.github.depromeet.knockknockbackend.global.utils.api.client.GoogleInfoClient;
+import io.github.depromeet.knockknockbackend.global.utils.api.client.GoogleUnlinkClient;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.GoogleInformationResponse;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.OIDCPublicKeysResponse;
 import java.net.URLDecoder;
@@ -23,6 +24,7 @@ public class GoogleOauthStrategy implements OauthStrategy {
     private final OauthProperties oauthProperties;
     private final GoogleAuthClient googleAuthClient;
     private final GoogleInfoClient googleInfoClient;
+    private final GoogleUnlinkClient googleUnlinkClient;
 
     private final OauthOIDCProvider oauthOIDCProvider;
 
@@ -58,6 +60,12 @@ public class GoogleOauthStrategy implements OauthStrategy {
         return oauthOIDCProvider.getPayloadFromIdToken(
                 token, ISSUER, oauthProperties.getGoogleClientId(), oidcPublicKeysResponse);
     }
+
+    @Override
+    public void unLink(String oauthAccessToken) {
+        googleUnlinkClient.unlink(oauthAccessToken);
+    }
+
     // 발급된 어세스 토큰으로 유저정보 조회
     public OauthCommonUserInfoDto getUserInfo(String oauthAccessToken) {
 

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/KakaoOauthStrategy.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/KakaoOauthStrategy.java
@@ -73,4 +73,9 @@ public class KakaoOauthStrategy implements OauthStrategy {
         return oauthOIDCProvider.getPayloadFromIdToken(
                 token, ISSUER, oauthProperties.getKakaoClientId(), oidcPublicKeysResponse);
     }
+
+    @Override
+    public void unLink(String oauthAccessToken) {
+        kakaoInfoClient.unlinkUser(PREFIX + oauthAccessToken);
+    }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthStrategy.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/credential/service/OauthStrategy.java
@@ -9,4 +9,6 @@ public interface OauthStrategy {
     String getAccessToken(String code);
 
     OIDCDecodePayload getOIDCDecodePayload(String token);
+
+    void unLink(String oauthAccessToken);
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/AccountState.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/AccountState.java
@@ -1,0 +1,19 @@
+package io.github.depromeet.knockknockbackend.domain.user.domain;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum AccountState {
+    NORMAL("NORMAL"),
+    // 탈퇴한유저
+    DELETED("DELETED"),
+    // 영구정지
+    FORBIDDEN("FORBIDDEN"),
+    // 7일정지등..? 나중을위한
+    SUSPENDED("SUSPENDED");
+
+    private String value;
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/User.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/user/domain/User.java
@@ -1,8 +1,12 @@
 package io.github.depromeet.knockknockbackend.domain.user.domain;
 
 
+import io.github.depromeet.knockknockbackend.domain.credential.event.DeleteUserEvent;
 import io.github.depromeet.knockknockbackend.domain.user.domain.vo.UserInfoVO;
+import io.github.depromeet.knockknockbackend.global.event.Events;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -33,6 +37,9 @@ public class User {
     private String email;
 
     private String profilePath;
+
+    @Enumerated(EnumType.STRING)
+    private AccountState accountState = AccountState.NORMAL;
 
     @Builder
     public User(
@@ -65,5 +72,15 @@ public class User {
     public void changeProfile(String nickname, String profilePath) {
         this.nickname = nickname;
         this.profilePath = profilePath;
+    }
+
+    public void softDeleteUser() {
+        String deletedPrefix = "Deleted:";
+        this.nickname = "탈퇴한 유저";
+        this.oauthId = deletedPrefix + this.oauthId;
+        this.email = deletedPrefix + this.email;
+        this.accountState = AccountState.DELETED;
+        DeleteUserEvent deleteUserEvent = DeleteUserEvent.builder().userId(this.id).build();
+        Events.raise(deleteUserEvent);
     }
 }

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/config/SecurityConfig.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/config/SecurityConfig.java
@@ -31,6 +31,8 @@ public class SecurityConfig {
                 .permitAll()
                 .antMatchers("/actuator/**")
                 .permitAll()
+                .antMatchers("/api/v1/credentials/me")
+                .authenticated()
                 .antMatchers("/api/v1/credentials/**")
                 .permitAll()
                 .antMatchers("/api/v1/asset/version")

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/event/DeleteUserEventHandler.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/event/DeleteUserEventHandler.java
@@ -1,0 +1,31 @@
+package io.github.depromeet.knockknockbackend.global.event;
+
+
+import io.github.depromeet.knockknockbackend.domain.credential.event.DeleteUserEvent;
+import io.github.depromeet.knockknockbackend.domain.group.domain.repository.GroupRepository;
+import io.github.depromeet.knockknockbackend.domain.group.domain.repository.GroupUserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DeleteUserEventHandler {
+
+    private final GroupRepository groupRepository;
+    private final GroupUserRepository groupUserRepository;
+
+    @Async
+    @TransactionalEventListener(
+            classes = DeleteUserEvent.class,
+            phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDeleteUserEvent(DeleteUserEvent deleteUserEvent) {
+        // TODO : // 기획 맞춰서 삭제하기
+        Long userId = deleteUserEvent.getUserId();
+        log.info(userId.toString() + "회원탈퇴");
+    }
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/GoogleUnlinkClient.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/GoogleUnlinkClient.java
@@ -1,0 +1,16 @@
+package io.github.depromeet.knockknockbackend.global.utils.api.client;
+
+
+import feign.Headers;
+import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.GoogleInformationResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "GoogleUnlinkClient", url = "https://oauth2.googleapis.com/revoke")
+public interface GoogleUnlinkClient {
+
+    @PostMapping
+    @Headers("Content-type:application/x-www-form-urlencoded")
+    GoogleInformationResponse unlink(@RequestParam("token") String oauthAccessToken);
+}

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/KakaoInfoClient.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/utils/api/client/KakaoInfoClient.java
@@ -4,6 +4,7 @@ package io.github.depromeet.knockknockbackend.global.utils.api.client;
 import io.github.depromeet.knockknockbackend.global.utils.api.dto.response.KakaoInformationResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "KakaoInfoClient", url = "https://kapi.kakao.com")
@@ -11,4 +12,7 @@ public interface KakaoInfoClient {
 
     @GetMapping("/v2/user/me")
     KakaoInformationResponse kakaoUserInfo(@RequestHeader("Authorization") String accessToken);
+
+    @PostMapping("/v1/user/unlink")
+    void unlinkUser(@RequestHeader("Authorization") String accessToken);
 }


### PR DESCRIPTION

탈퇴한 유저인경우 row 삭제대신

 - 닉네임 탈퇴한 유저로 변경
 - oauth unlink 수행
 - UserDeleteEvent 발행

정책에 따라서 각 도메인에서 대응해 주심 될것같습니다

```java
//example
public class DeleteUserEventHandler {

    private final GroupRepository groupRepository;
    private final GroupUserRepository groupUserRepository;

    @Async
    @TransactionalEventListener(
            classes = DeleteUserEvent.class,
            phase = TransactionPhase.AFTER_COMMIT)
    public void handleDeleteUserEvent(DeleteUserEvent deleteUserEvent) {
        // TODO : // 기획 맞춰서 삭제하기
        Long userId = deleteUserEvent.getUserId();
        log.info(userId.toString() + "회원탈퇴");
    }
}
```

