### PR TITLE
🔀 :: (#223) 슬랙 에러 알림 getRequest null 문제 해결

### DIFF
--- a/src/main/java/io/github/depromeet/knockknockbackend/global/slack/SlackProvider.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/slack/SlackProvider.java
@@ -34,10 +34,9 @@ public class SlackProvider {
     private final int MaxLength = 500;
 
     @Async
-    public void sendError(ContentCachingRequestWrapper cachingRequest, Exception e)
+    public void sendError(String url, ContentCachingRequestWrapper cachingRequest, Exception e)
             throws IOException {
         String method = cachingRequest.getMethod();
-        String url = cachingRequest.getRequestURL().toString();
         String body = objectMapper.readTree(cachingRequest.getContentAsByteArray()).toString();
         String exceptionAsString = Throwables.getStackTraceAsString(e);
         int cutLength = Math.min(exceptionAsString.length(), MaxLength);


### PR DESCRIPTION
java.lang.NullPointerException: null
        at org.apache.catalina.util.RequestUtil.getRequestURL(RequestUtil.java:51) ~[tomcat-embed-core-9.0.65.jar!/:na]
        at org.apache.catalina.connector.Request.getRequestURL(Request.java:2455) ~[tomcat-embed-core-9.0.65.jar!/:na]
        at org.apache.catalina.connector.RequestFacade.getRequestURL(RequestFacade.java:880) ~[tomcat-embed-core-9.0.65.jar!/:na]
        at javax.servlet.http.HttpServletRequestWrapper.getRequestURL(HttpServletRequestWrapper.java:226) ~[tomcat-embed-core-9.0.65.jar!/:na]
        at javax.servlet.http.HttpServletRequestWrapper.getRequestURL(HttpServletRequestWrapper.java:226) ~[tomcat-embed-core-9.0.65.jar!/:na]
        at javax.servlet.http.HttpServletRequestWrapper.getRequestURL(HttpServletRequestWrapper.java:226) ~[tomcat-embed-core-9.0.65.jar!/:na]
        at javax.servlet.http.HttpServletRequestWrapper.getRequestURL(HttpServletRequestWrapper.java:226) ~[tomcat-embed-core-9.0.65.jar!/:na]
        at javax.servlet.http.HttpServletRequestWrapper.getRequestURL(HttpServletRequestWrapper.java:226) ~[tomcat-embed-core-9.0.65.jar!/:na]
        at io.github.depromeet.knockknockbackend.global.slack.SlackProvider.sendError(SlackProvider.java:40) ~[classes!/:na]
        at io.github.depromeet.knockknockbackend.global.slack.SlackProvider$$FastClassBySpringCGLIB$$c82369d0.invoke(<generated>) ~[classes!/:na]
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.3.23.jar!/:5.3.23]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:793) ~[spring-aop-5.3.23.jar!/:5.3.23]
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.3.23.jar!/:5.3.23]
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:763) ~[spring-aop-5.3.23.jar!/:5.3.23]
        at org.springframework.aop.interceptor.AsyncExecutionInterceptor.lambda$invoke$0(AsyncExecutionInterceptor.java:115) ~[spring-aop-5.3.23.jar!/:5.3.23]
        at java.base/java.util.concurrent.FutureTask.run(Unknown Source) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[na:na]
        at java.base/java.lang.Thread.run(Unknown Source) ~[na:na]
