### PR TITLE
🔀 :: (#234) fcm 인증방식 환경변수로. 똑똑미리체험하기 회원가입전 가능하도록 수정

### DIFF
--- a/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/domain/notification/presentation/NotificationController.java
@@ -5,6 +5,7 @@ import io.github.depromeet.knockknockbackend.domain.notification.presentation.dt
 import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryNotificationListLatestResponse;
 import io.github.depromeet.knockknockbackend.domain.notification.presentation.dto.response.QueryNotificationListResponse;
 import io.github.depromeet.knockknockbackend.domain.notification.service.NotificationService;
+import io.github.depromeet.knockknockbackend.global.annotation.DisableSecurity;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -71,6 +72,7 @@ public class NotificationController {
     @Operation(summary = "똑똑 미리체험하기 : 회원가입 전 자신에게 푸쉬알림 보내기")
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/experience")
+    @DisableSecurity
     public void sendInstanceToMeBeforeSignUp(
             @RequestBody SendInstanceToMeBeforeSignUpRequest request) {
         notificationService.sendInstanceToMeBeforeSignUp(request);

--- a/src/main/java/io/github/depromeet/knockknockbackend/global/config/SecurityConfig.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/global/config/SecurityConfig.java
@@ -40,6 +40,8 @@ public class SecurityConfig {
                 .permitAll()
                 .antMatchers("/api/v1/asset/version")
                 .permitAll()
+                .antMatchers("/api/v1/notifications/experience")
+                .permitAll()
                 .antMatchers("/api/v1/asset/profiles/**")
                 .permitAll()
                 .anyRequest()

--- a/src/main/java/io/github/depromeet/knockknockbackend/infrastructor/fcm/FcmConfig.java
+++ b/src/main/java/io/github/depromeet/knockknockbackend/infrastructor/fcm/FcmConfig.java
@@ -4,7 +4,9 @@ package io.github.depromeet.knockknockbackend.infrastructor.fcm;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -21,10 +23,10 @@ public class FcmConfig {
             if (FirebaseApp.getApps().isEmpty()) {
                 FirebaseOptions options =
                         FirebaseOptions.builder()
-                                .setCredentials(GoogleCredentials.getApplicationDefault())
-                                //
-                                // .setCredentials(GoogleCredentials.fromStream(new
-                                // ByteArrayInputStream(fcmValue.getBytes(StandardCharsets.UTF_8))))
+                                .setCredentials(
+                                        GoogleCredentials.fromStream(
+                                                new ByteArrayInputStream(
+                                                        fcmValue.getBytes(StandardCharsets.UTF_8))))
                                 .build();
                 FirebaseApp.initializeApp(options);
             }


### PR DESCRIPTION
 - @DisableSecurity
 - 예전에 만들어논 어노테이션으로 스웨거에서 자물쇠 빼줬습니다
 - 인증방식 환경변수로 했고 배포서버에서는 docker secrete 으로 knock.env 에 적힌 fcm 환경변수 가져왔고슴다

 - close #234 